### PR TITLE
fix: don't process XML entities and deal with defined JSONElements

### DIFF
--- a/src/merger/XmlMerger.ts
+++ b/src/merger/XmlMerger.ts
@@ -8,6 +8,7 @@ const baseOptions = {
   cdataPropName: '__cdata',
   commentPropName: XML_COMMENT_PROP_NAME,
   ignoreAttributes: false,
+  processEntities: false,
 }
 
 const parserOptions = {

--- a/src/utils/mergeUtils.ts
+++ b/src/utils/mergeUtils.ts
@@ -20,7 +20,17 @@ export const ensureArray = (value: JsonValue): JsonArray =>
 
 export const getUniqueSortedProps = (
   ...objects: (JsonObject | JsonArray)[]
-): string[] => Array.from(new Set([...objects].map(Object.keys).flat())).sort()
+): string[] =>
+  Array.from(
+    new Set(
+      [...objects]
+        .filter(
+          jsonElement => ![undefined, null].includes(jsonElement as never)
+        )
+        .map(Object.keys)
+        .flat()
+    )
+  ).sort()
 
 export const detectEol = (text: string): string => {
   if (!text) {

--- a/test/unit/utils/mergeUtils.test.ts
+++ b/test/unit/utils/mergeUtils.test.ts
@@ -82,9 +82,17 @@ describe('mergeUtils', () => {
       const a = { b: 1, a: 2 }
       const b = { c: 3, a: 4 }
       const c = ['x', 'y'] // keys: '0','1'
+      const d = null
+      const e = undefined
 
       // Act
-      const result = getUniqueSortedProps(a as never, b as never, c as never)
+      const result = getUniqueSortedProps(
+        a as never,
+        b as never,
+        c as never,
+        d as never,
+        e as never
+      )
 
       // Assert
       expect(result).toEqual(['0', '1', 'a', 'b', 'c'])


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

1. configure `fast-xml-parser` to not process XML entities, we don't have any in the metadata and we should not. _Comes with a performance improvement_
2. make `getUniqueSortedProps` more robust by ensuring it flattens only defined JSONElement