### PR TITLE
fix: windows eol and path seperator in unit tests

### DIFF
--- a/test/unit/utils/gitUtils.test.ts
+++ b/test/unit/utils/gitUtils.test.ts
@@ -1,3 +1,4 @@
+import { sep } from 'node:path'
 import { getGitAttributesPath } from '../../../src/utils/gitUtils.js'
 
 const mockRevparse = jest.fn()
@@ -23,7 +24,7 @@ describe('gitUtils.getGitAttributesPath', () => {
 
     // Assert
     expect(mockRevparse).toHaveBeenCalledWith(['--git-dir'])
-    expect(result).toBe('.git/info/attributes')
+    expect(result).toBe('.git' + sep + 'info' + sep + 'attributes')
   })
 
   it('when git revparse fails then getGitAttributesPath should propagate the error', async () => {

--- a/test/unit/utils/mergeUtils.test.ts
+++ b/test/unit/utils/mergeUtils.test.ts
@@ -149,10 +149,16 @@ describe('mergeUtils', () => {
       }
       const cases: Case[] = [
         {
-          name: 'given eol undefined then returns platform EOL',
+          name: 'given eol undefined and CRLF in file then returns platform EOL',
           input: 'a\r\nb\r\n',
           eol: undefined as unknown as never,
-          expected: 'a\nb\n',
+          expected: 'a' + EOL + 'b' + EOL,
+        },
+        {
+          name: 'given eol undefined and LF in file then returns platform EOL',
+          input: 'a\nb\n',
+          eol: undefined as unknown as never,
+          expected: 'a' + EOL + 'b' + EOL,
         },
         {
           name: 'given input undefined then returns undefined',


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->
Fixing tests for windows compliance
Related to #105

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
