### PR TITLE
build: add launch.json for debugging in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `launch.json` file to enable debugging in VS Code. This configuration simplifies the process of attaching the VS Code debugger to a running Node.js process, improving the development experience.