### PR TITLE
feat: add aliases enable (=install) or disable (=uninstall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Installs a local git merge driver for the given org and branch.
 USAGE
   $ sf git merge driver install [--json] [--flags-dir <value>]
 
+ALIASES
+  $ sf git merge driver enable
+
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.
   --json               Format output as json.
@@ -247,6 +250,9 @@ Uninstalls the local git merge driver for the given org and branch.
 ```
 USAGE
   $ sf git merge driver uninstall [--json] [--flags-dir <value>]
+
+ALIASES
+  $ sf git merge driver disable
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -11,6 +11,9 @@ const messages = Messages.loadMessages(PLUGIN_NAME, 'install')
 
 export default class Install extends SfCommand<void> {
   public static override readonly summary = messages.getMessage('summary')
+  public static override readonly aliases: string[] = [
+    'git:merge:driver:enable',
+  ]
   public static override readonly description =
     messages.getMessage('description')
   public static override readonly examples = messages.getMessages('examples')

--- a/src/commands/git/merge/driver/uninstall.ts
+++ b/src/commands/git/merge/driver/uninstall.ts
@@ -13,6 +13,9 @@ export default class Uninstall extends SfCommand<void> {
   public static override readonly description =
     messages.getMessage('description')
   public static override readonly examples = messages.getMessages('examples')
+  public static override readonly aliases: string[] = [
+    'git:merge:driver:disable',
+  ]
 
   public static override readonly flags = {}
 


### PR DESCRIPTION
# Explain your changes

Adds aliases 'enable' and 'disable' to the 'install' and 'uninstall' commands, respectively, for improved usability.
