### PR TITLE
chore(ci): replace npm dev publishing with GitHub prerelease assets

### DIFF
--- a/.github/workflows/npm-service.yml
+++ b/.github/workflows/npm-service.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
     paths-ignore:
       - "**.md"
 
@@ -14,21 +14,19 @@ permissions:
   contents: read
   id-token: write
 
-# Manage concurrency to stop running jobs and start new ones in case of new commit pushed
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
   publish:
-    if: github.event_name == 'release' || github.actor != 'dependabot[bot]'
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.publish.outputs.channel }}
     permissions:
       id-token: write
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -38,65 +36,98 @@ jobs:
       - run: npm install -g npm@latest
       - uses: ./.github/actions/install
 
-      # Dev version setup (PR only)
-      - name: Compute dev version
-        if: github.event_name == 'pull_request'
-        id: version
-        run: |
-          CURRENT_VERSION=$(jq -r '.version' package.json)
-          DEV_CHANNEL="dev-${{ github.event.pull_request.number }}"
-          DEV_VERSION="${CURRENT_VERSION}-${DEV_CHANNEL}.${{ github.run_id }}-${{ github.run_attempt }}"
-          echo "channel=$DEV_CHANNEL" >> "$GITHUB_OUTPUT"
-          echo "version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Set dev version
-        if: github.event_name == 'pull_request'
-        env:
-          DEV_CHANNEL: ${{ steps.version.outputs.channel }}
-        run: |
-          git config --global user.email "${DEV_CHANNEL}@github.com"
-          git config --global user.name "$DEV_CHANNEL"
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
-
-      # Publish (unified with conditional channel)
       - name: Publish
         id: publish
         env:
-          DEV_CHANNEL: ${{ steps.version.outputs.channel }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            CHANNEL="$DEV_CHANNEL"
+          npm publish --provenance --access public --tag "latest-rc"
+          echo "channel=sf-git-merge-driver@$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+  dev-release:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.release.outputs.channel }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - uses: ./.github/actions/install
+
+      - name: Build and pack
+        id: pack
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          npm run build
+          TARBALL=$(npm pack 2>/dev/null | tail -1)
+          FIXED_NAME="sf-git-merge-driver-dev-pr-${PR_NUMBER}.tgz"
+          mv "$TARBALL" "$FIXED_NAME"
+          echo "tarball=$FIXED_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert prerelease
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: |
+          DEV_TAG="dev-pr-${PR_NUMBER}"
+
+          # Try uploading to existing release, create if it doesn't exist
+          if gh release view "$DEV_TAG" > /dev/null 2>&1; then
+            gh release upload "$DEV_TAG" "$TARBALL" --clobber
           else
-            CHANNEL="latest-rc"
-          fi
-          npm publish --provenance --access public --tag "$CHANNEL"
-          # For e2e: PR uses dev channel, release uses tag name (e.g., v1.5.0)
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "channel=$DEV_CHANNEL" >> "$GITHUB_OUTPUT"
-          else
-            echo "channel=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+            gh release create "$DEV_TAG" "$TARBALL" \
+              --title "Dev build for PR #${PR_NUMBER}" \
+              --notes "Automated dev build — not a real release." \
+              --prerelease
           fi
 
-      # Comment PR (PR only)
+          ASSET_URL=$(gh release view "$DEV_TAG" --json assets --jq ".assets[] | select(.name == \"$TARBALL\") | .url")
+          echo "channel=$ASSET_URL" >> "$GITHUB_OUTPUT"
+
       - name: Comment PR
-        if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v3
-        env:
-          DEV_CHANNEL: ${{ steps.version.outputs.channel }}
         with:
           message: |
-            Published under `${{ env.DEV_CHANNEL }}` npm channel.
+            Published under `dev-pr-${{ github.event.pull_request.number }}` draft release.
             ```sh
-            $ sf plugins install sf-git-merge-driver@${{ env.DEV_CHANNEL }}
+            sf plugins install ${{ steps.release.outputs.channel }}
             ```
           comment-tag: dev-publish
           mode: recreate
 
+  cleanup:
+    if: >-
+      github.event.action == 'closed' &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete dev prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          DEV_TAG="dev-pr-${PR_NUMBER}"
+          gh release delete "$DEV_TAG" \
+            --repo "${{ github.repository }}" \
+            --yes \
+            --cleanup-tag 2>/dev/null || echo "No release to clean up"
+
   e2e-tests:
-    needs: [publish]
+    needs: [publish, dev-release]
+    if: "!cancelled() && (needs.publish.result == 'success' || needs.dev-release.result == 'success')"
     uses: ./.github/workflows/run-e2e-tests.yml
     with:
-      channel: ${{ needs.publish.outputs.channel }}
-
+      channel: ${{ needs.publish.outputs.channel || needs.dev-release.outputs.channel }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install -g @salesforce/cli
 
       - name: Install new plugin version
-        run: echo y | sf plugins install sf-git-merge-driver@${{ inputs.channel }}
+        run: echo y | sf plugins install ${{ inputs.channel }}
 
       - name: Test new plugin version installation
         run: sf git merge driver --help


### PR DESCRIPTION
# Explain your changes

---

Apply the same prerelease dev build approach as sfdx-git-delta: instead of publishing dev versions to npm on every PR push, upload a tarball as a GitHub prerelease asset.

Changes to `npm-service.yml`:
- `publish` job now only runs on `release` events, outputs `sf-git-merge-driver@<tag>`
- New `dev-release` job (PR only, not dependabot): builds, packs, uploads tarball to a GitHub prerelease tagged `dev-pr-<number>`, and comments the PR with the install URL
- New `cleanup` job: deletes the prerelease when the PR is closed
- `e2e-tests` job depends on both `publish` and `dev-release`, running whichever succeeded

Changes to `run-e2e-tests.yml`:
- Install step now uses `sf plugins install ${{ inputs.channel }}` (accepts either a full asset URL or `sf-git-merge-driver@version`)

# Does this close any currently open issues?

---

N/A

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

`sf plugins install <URL>` from the PR comment posted by the `dev-release` job.

# Any other comments

---

Validated in scolladon/oidc-cleanup-test