### PR TITLE
feat(perf): add comprehensive performance testing infrastructure

### DIFF
--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -19,11 +19,68 @@ jobs:
   prepare-release:
     needs: [build]
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.RELEASE_PAT }}
           release-type: node
+
+  perf:
+    needs: [prepare-release]
+    runs-on: ubuntu-latest
+    if: ${{ needs.prepare-release.outputs.release_created != 'true' && needs.prepare-release.outputs.prs_created == 'true' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: google/wireit@setup-github-actions-caching/v2
+
+      - name: Setup dependencies, cache and install
+        uses: ./.github/actions/install
+
+      - name: Run benchmarks
+        run: npm run test:perf
+
+      - name: Track runtime
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Runtime Benchmark
+          tool: customBiggerIsBetter
+          output-file-path: ./perf-runtime.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '130%'
+          comment-on-alert: true
+          fail-on-alert: true
+          summary-always: true
+          alert-comment-cc-users: '@scolladon'
+          benchmark-data-dir-path: dev/bench/runtime
+
+      - name: Track memory
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Memory Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: true
+          summary-always: true
+          alert-comment-cc-users: '@scolladon'
+          benchmark-data-dir-path: dev/bench/memory

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -9,7 +9,8 @@ on:
       - "**.md"
 
 permissions:
-  contents: 'read'
+  contents: write
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      prs_created: ${{ steps.release.outputs.prs_created }}
     permissions:
       contents: write
       pull-requests: write
@@ -34,54 +33,8 @@ jobs:
 
   perf:
     needs: [prepare-release]
-    runs-on: ubuntu-latest
     if: ${{ needs.prepare-release.outputs.release_created != 'true' }}
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - uses: google/wireit@setup-github-actions-caching/v2
-
-      - name: Setup dependencies, cache and install
-        uses: ./.github/actions/install
-
-      - name: Run benchmarks
-        run: npm run test:perf
-
-      - name: Track runtime
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Runtime Benchmark
-          tool: customBiggerIsBetter
-          output-file-path: ./perf-runtime.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          alert-threshold: '130%'
-          comment-on-alert: true
-          fail-on-alert: true
-          summary-always: true
-          alert-comment-cc-users: '@scolladon'
-          benchmark-data-dir-path: dev/bench/runtime
-
-      - name: Track memory
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Memory Benchmark
-          tool: customSmallerIsBetter
-          output-file-path: ./perf-memory.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          skip-fetch-gh-pages: true
-          alert-threshold: '150%'
-          comment-on-alert: true
-          fail-on-alert: true
-          summary-always: true
-          alert-comment-cc-users: '@scolladon'
-          benchmark-data-dir-path: dev/bench/memory
+    uses: ./.github/workflows/reusable-perf.yml
+    secrets: inherit
+    with:
+      auto-push: true

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -35,7 +35,7 @@ jobs:
   perf:
     needs: [prepare-release]
     runs-on: ubuntu-latest
-    if: ${{ needs.prepare-release.outputs.release_created != 'true' && needs.prepare-release.outputs.prs_created == 'true' }}
+    if: ${{ needs.prepare-release.outputs.release_created != 'true' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -78,6 +78,7 @@ jobs:
           output-file-path: ./perf-memory.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
+          skip-fetch-gh-pages: true
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/on-published-release.yml
+++ b/.github/workflows/on-published-release.yml
@@ -7,50 +7,10 @@ on:
       - published
 
 permissions: # required if repository sets restricted permissions for token, see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
-  contents: write # required for benchmark auto-push to gh-pages
   issues: write # required if active on issues
   pull-requests: write # required if active on pull requests
 
 jobs:
-  perf-on-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - uses: google/wireit@setup-github-actions-caching/v2
-
-      - name: Setup dependencies, cache and install
-        uses: ./.github/actions/install
-
-      - name: Run benchmarks
-        run: npm run test:perf
-
-      - name: Store release runtime benchmark
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Release Runtime Benchmark
-          tool: customBiggerIsBetter
-          output-file-path: ./perf-runtime.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          benchmark-data-dir-path: releases/bench/runtime
-
-      - name: Store release memory benchmark
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Release Memory Benchmark
-          tool: customSmallerIsBetter
-          output-file-path: ./perf-memory.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          benchmark-data-dir-path: releases/bench/memory
-
   release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-published-release.yml
+++ b/.github/workflows/on-published-release.yml
@@ -7,10 +7,50 @@ on:
       - published
 
 permissions: # required if repository sets restricted permissions for token, see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+  contents: write # required for benchmark auto-push to gh-pages
   issues: write # required if active on issues
   pull-requests: write # required if active on pull requests
 
 jobs:
+  perf-on-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: google/wireit@setup-github-actions-caching/v2
+
+      - name: Setup dependencies, cache and install
+        uses: ./.github/actions/install
+
+      - name: Run benchmarks
+        run: npm run test:perf
+
+      - name: Store release runtime benchmark
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Release Runtime Benchmark
+          tool: customBiggerIsBetter
+          output-file-path: ./perf-runtime.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          benchmark-data-dir-path: releases/bench/runtime
+
+      - name: Store release memory benchmark
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Release Memory Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          benchmark-data-dir-path: releases/bench/memory
+
   release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,7 +9,8 @@ on:
       - "**.md"
 
 permissions:
-  contents: 'read'
+  contents: write
+  pull-requests: write
 
 # Manage concurrency to stop running jobs and start new ones in case of new commit pushed
 concurrency:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -101,3 +101,35 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
+
+  perf:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: google/wireit@setup-github-actions-caching/v2
+
+      - name: Setup dependencies, cache and install
+        uses: ./.github/actions/install
+
+      - name: Run benchmarks
+        run: npm run test:perf
+
+      - name: Generate preview
+        run: node test/perf/preview.mjs
+
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-report
+          path: |
+            perf-preview.html
+            perf-runtime.json
+            perf-memory.json

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: 'read'
+  pull-requests: write
 
 # Manage concurrency to stop running jobs and start new ones in case of new commit pushed
 concurrency:
@@ -124,6 +125,36 @@ jobs:
 
       - name: Generate preview
         run: node test/perf/preview.mjs
+
+      - name: Compare runtime against baseline
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Runtime Benchmark
+          tool: customBiggerIsBetter
+          output-file-path: ./perf-runtime.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          save-data-file: false
+          alert-threshold: '130%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@scolladon'
+          benchmark-data-dir-path: dev/bench/runtime
+
+      - name: Compare memory against baseline
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Memory Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          save-data-file: false
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@scolladon'
+          benchmark-data-dir-path: dev/bench/memory
 
       - name: Upload benchmark report
         uses: actions/upload-artifact@v6

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: 'read'
-  pull-requests: write
 
 # Manage concurrency to stop running jobs and start new ones in case of new commit pushed
 concurrency:
@@ -105,69 +104,5 @@ jobs:
 
   perf:
     needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - uses: google/wireit@setup-github-actions-caching/v2
-
-      - name: Setup dependencies, cache and install
-        uses: ./.github/actions/install
-
-      - name: Checkout gh-pages baseline data
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          path: gh-pages-data
-
-      - name: Run benchmarks
-        run: npm run test:perf
-
-      - name: Generate preview with trends
-        run: node test/perf/preview.mjs gh-pages-data
-
-      - name: Compare runtime against baseline
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Runtime Benchmark
-          tool: customBiggerIsBetter
-          output-file-path: ./perf-runtime.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-          save-data-file: false
-          alert-threshold: '130%'
-          comment-on-alert: true
-          fail-on-alert: true
-          alert-comment-cc-users: '@scolladon'
-          benchmark-data-dir-path: dev/bench/runtime
-
-      - name: Compare memory against baseline
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Memory Benchmark
-          tool: customSmallerIsBetter
-          output-file-path: ./perf-memory.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-          save-data-file: false
-          skip-fetch-gh-pages: true
-          alert-threshold: '150%'
-          comment-on-alert: true
-          fail-on-alert: true
-          alert-comment-cc-users: '@scolladon'
-          benchmark-data-dir-path: dev/bench/memory
-
-      - name: Upload benchmark report
-        uses: actions/upload-artifact@v6
-        with:
-          name: perf-report
-          path: |
-            perf-preview.html
-            perf-runtime.json
-            perf-memory.json
+    uses: ./.github/workflows/reusable-perf.yml
+    secrets: inherit

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -120,11 +120,17 @@ jobs:
       - name: Setup dependencies, cache and install
         uses: ./.github/actions/install
 
+      - name: Checkout gh-pages baseline data
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages-data
+
       - name: Run benchmarks
         run: npm run test:perf
 
-      - name: Generate preview
-        run: node test/perf/preview.mjs
+      - name: Generate preview with trends
+        run: node test/perf/preview.mjs gh-pages-data
 
       - name: Compare runtime against baseline
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -156,6 +156,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: false
           save-data-file: false
+          skip-fetch-gh-pages: true
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/reusable-perf.yml
+++ b/.github/workflows/reusable-perf.yml
@@ -1,0 +1,83 @@
+---
+name: Performance Benchmarks
+on:
+  workflow_call:
+    inputs:
+      auto-push:
+        description: Push benchmark data to gh-pages
+        type: boolean
+        default: false
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: google/wireit@setup-github-actions-caching/v2
+
+      - name: Setup dependencies, cache and install
+        uses: ./.github/actions/install
+
+      - name: Checkout gh-pages baseline data
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages-data
+
+      - name: Run benchmarks
+        run: npm run test:perf
+
+      - name: Generate preview with trends
+        run: node test/perf/preview.mjs gh-pages-data
+
+      - name: Runtime benchmark
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Runtime Benchmark
+          tool: customBiggerIsBetter
+          output-file-path: ./perf-runtime.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ inputs.auto-push }}
+          save-data-file: ${{ inputs.auto-push }}
+          alert-threshold: '130%'
+          comment-on-alert: true
+          fail-on-alert: true
+          summary-always: ${{ inputs.auto-push }}
+          alert-comment-cc-users: '@scolladon'
+          benchmark-data-dir-path: dev/bench/runtime
+
+      - name: Memory benchmark
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Memory Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ inputs.auto-push }}
+          save-data-file: ${{ inputs.auto-push }}
+          skip-fetch-gh-pages: true
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: true
+          summary-always: ${{ inputs.auto-push }}
+          alert-comment-cc-users: '@scolladon'
+          benchmark-data-dir-path: dev/bench/memory
+
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-report
+          path: |
+            perf-preview.html
+            perf-runtime.json
+            perf-memory.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@
 e2e
 install-state.gz
 megalinter-reports/
+perf-raw.json
 perf-result.txt
+perf-runtime.json
+perf-memory.json
 stderr*.txt
 stdout*.txt
 tsconfig.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 e2e
 install-state.gz
 megalinter-reports/
+perf-preview.html
 perf-raw.json
 perf-result.txt
 perf-runtime.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-MIT-blue)]()
 [![Compatibility](https://img.shields.io/badge/Windows%20%7C%20Mac%20%7C%20Linux-Supported-success)]()
+[![Performance](https://img.shields.io/badge/Performance-Dashboard-58a6ff)](https://scolladon.github.io/sf-git-merge-driver/dev/bench/runtime/)
 
 An intelligent Git merge driver specifically designed for Salesforce metadata files. **Eliminates hours** of manual merge conflicts resolution.
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -2,6 +2,7 @@ export default {
   entry: [
     '.github/**/*.yml',
     '**/*.{nut,test}.ts',
+    'test/perf/**/*.{ts,mjs}',
     'bin/dev.js',
     'bin/run.js',
     'src/commands/git/merge/driver/install.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "typescript": "^5.9.3",
+        "vitest": "^3.2.1",
         "wireit": "^0.14.12"
       },
       "engines": {
@@ -1890,6 +1891,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
+      "integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
+      "integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
+      "integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
+      "integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
+      "integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
+      "integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
+      "integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
+      "integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
+      "integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
+      "integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
+      "integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
+      "integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
+      "integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
+      "integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
+      "integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
+      "integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
+      "integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
+      "integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
+      "integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
+      "integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
+      "integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
+      "integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
+      "integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -4850,6 +5293,395 @@
         "node": ">=12"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@salesforce/cli-plugins-testkit": {
       "version": "5.3.41",
       "resolved": "https://registry.npmjs.org/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.41.tgz",
@@ -5913,6 +6745,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -6321,6 +7160,138 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6910,6 +7881,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -7134,6 +8115,16 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -7636,6 +8627,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -7857,6 +8858,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7890,6 +8898,48 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
+      "integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.5",
+        "@esbuild/android-arm": "0.27.5",
+        "@esbuild/android-arm64": "0.27.5",
+        "@esbuild/android-x64": "0.27.5",
+        "@esbuild/darwin-arm64": "0.27.5",
+        "@esbuild/darwin-x64": "0.27.5",
+        "@esbuild/freebsd-arm64": "0.27.5",
+        "@esbuild/freebsd-x64": "0.27.5",
+        "@esbuild/linux-arm": "0.27.5",
+        "@esbuild/linux-arm64": "0.27.5",
+        "@esbuild/linux-ia32": "0.27.5",
+        "@esbuild/linux-loong64": "0.27.5",
+        "@esbuild/linux-mips64el": "0.27.5",
+        "@esbuild/linux-ppc64": "0.27.5",
+        "@esbuild/linux-riscv64": "0.27.5",
+        "@esbuild/linux-s390x": "0.27.5",
+        "@esbuild/linux-x64": "0.27.5",
+        "@esbuild/netbsd-arm64": "0.27.5",
+        "@esbuild/netbsd-x64": "0.27.5",
+        "@esbuild/openbsd-arm64": "0.27.5",
+        "@esbuild/openbsd-x64": "0.27.5",
+        "@esbuild/openharmony-arm64": "0.27.5",
+        "@esbuild/sunos-x64": "0.27.5",
+        "@esbuild/win32-arm64": "0.27.5",
+        "@esbuild/win32-ia32": "0.27.5",
+        "@esbuild/win32-x64": "0.27.5"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -7925,6 +8975,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -8002,6 +9062,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-copy": {
@@ -11658,6 +12728,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -11688,6 +12765,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -12177,6 +13264,25 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/napi-postinstall": {
@@ -12946,6 +14052,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -13117,6 +14240,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pretty-format": {
@@ -13617,6 +14769,51 @@
         "node": "*"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -14014,6 +15211,13 @@
         "which": "bin/which"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -14202,6 +15406,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -14351,6 +15565,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -14496,6 +15724,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strnum": {
       "version": "2.1.2",
@@ -14714,6 +15962,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -14757,6 +16019,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -15197,6 +16489,238 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -15278,6 +16802,23 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/widest-line": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3",
+    "vitest": "^3.2.1",
     "wireit": "^0.14.12"
   },
   "engines": {
@@ -89,6 +90,7 @@
     "prepublishOnly": "npm shrinkwrap",
     "test:build": "wireit",
     "test:nut": "wireit",
+    "test:perf": "wireit",
     "test:unit": "wireit",
     "test": "wireit"
   },
@@ -103,7 +105,7 @@
       ]
     },
     "clean": {
-      "command": "shx rm -rf 'reports/*' .nyc_output oclif.manifest.json package.tgz 'sfdx-git-delta-*.tgz' 'stderr*.txt' 'stdout*.txt' '.stryker-tmp/*' perf-result.txt",
+      "command": "shx rm -rf 'reports/*' .nyc_output oclif.manifest.json package.tgz 'sfdx-git-delta-*.tgz' 'stderr*.txt' 'stdout*.txt' '.stryker-tmp/*' perf-result.txt perf-raw.json perf-runtime.json perf-memory.json",
       "files": [
         "lib",
         "reports/*",
@@ -114,7 +116,10 @@
         "stderr*.txt",
         "stdout*.txt",
         ".stryker-tmp/*",
-        "perf-result.txt"
+        "perf-result.txt",
+        "perf-raw.json",
+        "perf-runtime.json",
+        "perf-memory.json"
       ],
       "dependencies": [
         "clean:build"
@@ -263,6 +268,23 @@
       ],
       "dependencies": [
         "lint"
+      ]
+    },
+    "test:perf": {
+      "command": "node --expose-gc ./node_modules/.bin/vitest bench --config vitest.config.perf.ts && node test/perf/formatResults.mjs",
+      "files": [
+        "src/**/*.ts",
+        "test/perf/**",
+        "**/tsconfig.json",
+        "vitest.config.perf.ts"
+      ],
+      "output": [
+        "perf-raw.json",
+        "perf-runtime.json",
+        "perf-memory.json"
+      ],
+      "dependencies": [
+        "compile"
       ]
     }
   }

--- a/src/merger/XmlMerger.ts
+++ b/src/merger/XmlMerger.ts
@@ -10,14 +10,14 @@ import { log } from '../utils/LoggingDecorator.js'
 import { ConflictMarkerFormatter } from './ConflictMarkerFormatter.js'
 import { JsonMerger } from './JsonMerger.js'
 
-const baseOptions = {
+export const baseOptions = {
   cdataPropName: CDATA_PROP_NAME,
   commentPropName: XML_COMMENT_PROP_NAME,
   ignoreAttributes: false,
   processEntities: false,
 }
 
-const parserOptions = {
+export const parserOptions = {
   ...baseOptions,
   ignoreDeclaration: true,
   numberParseOptions: { leadingZeros: false, hex: false },
@@ -25,7 +25,7 @@ const parserOptions = {
   parseTagValue: false,
 }
 
-const builderOptions = {
+export const builderOptions = {
   ...baseOptions,
   format: true,
   indentBy: XML_INDENT,

--- a/test/perf/fixtures/generateFixtures.ts
+++ b/test/perf/fixtures/generateFixtures.ts
@@ -163,6 +163,58 @@ const customValue = (index: number, isActive: boolean): string =>
         <label>Value ${index}</label>
     </customValue>`
 
+const picklistValue = (index: number, isActive: boolean): string =>
+  `
+            <value>
+                <fullName>PickValue_${String(index).padStart(3, '0')}</fullName>
+                <default>false</default>
+                <isActive>${isActive}</isActive>
+                <label>Pick Value ${index}</label>
+            </value>`
+
+const buildPicklistField = (values: readonly string[]): string =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Status__c</fullName>
+    <description>Status picklist</description>
+    <label>Status</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>false</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>${values.join('')}
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>`
+
+export const generatePicklistFixtures = (): OrderedFixtures => {
+  const valueCount = 30
+
+  const ancestorValues = Array.from({ length: valueCount }, (_, i) =>
+    picklistValue(i, true)
+  )
+  const ancestor = buildPicklistField(ancestorValues)
+
+  const localValues = [
+    ...ancestorValues.slice(0, 8),
+    ...ancestorValues.slice(15, 22),
+    ...ancestorValues.slice(8, 15),
+    ...ancestorValues.slice(22),
+    picklistValue(valueCount, true),
+    picklistValue(valueCount + 1, true),
+  ]
+  const local = buildPicklistField(localValues)
+
+  const otherValues = ancestorValues
+    .filter((_, i) => i !== 5 && i !== 20)
+    .map((v, i) => (i < 3 ? picklistValue(i, false) : v))
+  const other = buildPicklistField(otherValues)
+
+  return { ancestor, local, other }
+}
+
 export const generateOrderedFixtures = (): OrderedFixtures => {
   const valueCount = 40
 

--- a/test/perf/fixtures/generateFixtures.ts
+++ b/test/perf/fixtures/generateFixtures.ts
@@ -1,0 +1,198 @@
+const PROFILE_HEADER =
+  '<?xml version="1.0" encoding="UTF-8"?>\n<Profile xmlns="http://soap.sforce.com/2006/04/metadata">'
+const PROFILE_FOOTER = '\n</Profile>'
+
+const GLOBAL_VALUE_SET_HEADER =
+  '<?xml version="1.0" encoding="UTF-8"?>\n<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">'
+const GLOBAL_VALUE_SET_FOOTER = '\n</GlobalValueSet>'
+
+type FixtureSize = 'small' | 'medium' | 'large'
+
+interface SizeConfig {
+  readonly fieldPermissions: number
+  readonly classAccesses: number
+  readonly objectPermissions: number
+}
+
+const SIZE_CONFIGS: Record<FixtureSize, SizeConfig> = {
+  small: { fieldPermissions: 50, classAccesses: 10, objectPermissions: 5 },
+  medium: { fieldPermissions: 500, classAccesses: 50, objectPermissions: 20 },
+  large: {
+    fieldPermissions: 2000,
+    classAccesses: 200,
+    objectPermissions: 50,
+  },
+}
+
+interface ProfileFixtures {
+  readonly ancestor: string
+  readonly local: string
+  readonly other: string
+  readonly conflictLocal: string
+  readonly conflictOther: string
+}
+
+interface OrderedFixtures {
+  readonly ancestor: string
+  readonly local: string
+  readonly other: string
+}
+
+const fieldPermission = (
+  index: number,
+  editable: boolean,
+  readable: boolean
+): string =>
+  `
+    <fieldPermissions>
+        <editable>${editable}</editable>
+        <field>Account.CustomField_${String(index).padStart(4, '0')}__c</field>
+        <readable>${readable}</readable>
+    </fieldPermissions>`
+
+const classAccess = (index: number, enabled: boolean): string =>
+  `
+    <classAccesses>
+        <apexClass>MyClass${String(index).padStart(4, '0')}</apexClass>
+        <enabled>${enabled}</enabled>
+    </classAccesses>`
+
+const objectPermission = (
+  index: number,
+  allowRead: boolean,
+  allowEdit: boolean
+): string =>
+  `
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>${allowEdit}</allowEdit>
+        <allowRead>${allowRead}</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>CustomObject${String(index).padStart(4, '0')}__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>`
+
+const buildProfile = (parts: readonly string[]): string =>
+  PROFILE_HEADER + parts.join('') + PROFILE_FOOTER
+
+const generateBaseElements = (
+  config: SizeConfig
+): {
+  readonly fields: readonly string[]
+  readonly classes: readonly string[]
+  readonly objects: readonly string[]
+} => ({
+  fields: Array.from({ length: config.fieldPermissions }, (_, i) =>
+    fieldPermission(i, true, true)
+  ),
+  classes: Array.from({ length: config.classAccesses }, (_, i) =>
+    classAccess(i, true)
+  ),
+  objects: Array.from({ length: config.objectPermissions }, (_, i) =>
+    objectPermission(i, true, false)
+  ),
+})
+
+export const generateProfileFixtures = (size: FixtureSize): ProfileFixtures => {
+  const config = SIZE_CONFIGS[size]
+  const base = generateBaseElements(config)
+  const quarter = Math.floor(config.fieldPermissions / 4)
+  const eighth = Math.floor(config.fieldPermissions / 8)
+
+  const ancestor = buildProfile([
+    ...base.fields,
+    ...base.classes,
+    ...base.objects,
+  ])
+
+  const localFields = base.fields.map((field, i) =>
+    i < quarter ? fieldPermission(i, false, true) : field
+  )
+  const localExtra = Array.from({ length: 5 }, (_, i) =>
+    fieldPermission(config.fieldPermissions + i, true, true)
+  )
+  const local = buildProfile([
+    ...localFields,
+    ...localExtra,
+    ...base.classes,
+    ...base.objects,
+  ])
+
+  const otherFields = base.fields
+    .map((field, i) =>
+      i >= quarter && i < quarter * 2 ? fieldPermission(i, true, false) : field
+    )
+    .filter((_, i) => i < config.fieldPermissions - 3)
+  const other = buildProfile([...otherFields, ...base.classes, ...base.objects])
+
+  const conflictLocalFields = base.fields.map((field, i) =>
+    i < quarter ? fieldPermission(i, true, true) : field
+  )
+  const conflictLocal = buildProfile([
+    ...conflictLocalFields,
+    ...localExtra,
+    ...base.classes,
+    ...base.objects,
+  ])
+
+  const conflictOtherFields = base.fields.map((field, i) => {
+    if (i < eighth) {
+      return fieldPermission(i, false, true)
+    }
+    if (i >= quarter && i < quarter * 2) {
+      return fieldPermission(i, true, false)
+    }
+    return field
+  })
+  const conflictOther = buildProfile([
+    ...conflictOtherFields,
+    ...base.classes,
+    ...base.objects,
+  ])
+
+  return { ancestor, local, other, conflictLocal, conflictOther }
+}
+
+const customValue = (index: number, isActive: boolean): string =>
+  `
+    <customValue>
+        <fullName>Value_${String(index).padStart(3, '0')}</fullName>
+        <default>false</default>
+        <isActive>${isActive}</isActive>
+        <label>Value ${index}</label>
+    </customValue>`
+
+export const generateOrderedFixtures = (): OrderedFixtures => {
+  const valueCount = 40
+
+  const ancestorValues = Array.from({ length: valueCount }, (_, i) =>
+    customValue(i, true)
+  )
+  const ancestor =
+    GLOBAL_VALUE_SET_HEADER + ancestorValues.join('') + GLOBAL_VALUE_SET_FOOTER
+
+  const localValues = [
+    ...ancestorValues.slice(0, 10),
+    ...ancestorValues.slice(20, 30),
+    ...ancestorValues.slice(10, 20),
+    ...ancestorValues.slice(30),
+    customValue(valueCount, true),
+    customValue(valueCount + 1, true),
+  ]
+  const local =
+    GLOBAL_VALUE_SET_HEADER + localValues.join('') + GLOBAL_VALUE_SET_FOOTER
+
+  const otherValues = [
+    ...ancestorValues.slice(0, 5),
+    ...ancestorValues.slice(15, 25),
+    ...ancestorValues.slice(5, 15),
+    ...ancestorValues.slice(25),
+    customValue(valueCount + 2, true),
+    customValue(valueCount + 3, true),
+  ]
+  const other =
+    GLOBAL_VALUE_SET_HEADER + otherValues.join('') + GLOBAL_VALUE_SET_FOOTER
+
+  return { ancestor, local, other }
+}

--- a/test/perf/flamegraph-runner.mjs
+++ b/test/perf/flamegraph-runner.mjs
@@ -1,0 +1,79 @@
+/**
+ * Hot loop runner for flamegraph generation via 0x (local only, not CI).
+ *
+ * Usage:
+ *   npx 0x -- node test/perf/flamegraph-runner.mjs [small|medium|large]
+ *
+ * Runs XmlMerger.mergeThreeWay() in a tight loop for clean flamegraph profiling.
+ */
+
+import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import {
+  CDATA_PROP_NAME,
+  XML_COMMENT_PROP_NAME,
+  XML_DECL,
+  XML_INDENT,
+} from '../../src/constant/parserConstant.js'
+import { ConflictMarkerFormatter } from '../../src/merger/ConflictMarkerFormatter.js'
+import { JsonMerger } from '../../src/merger/JsonMerger.js'
+import { generateProfileFixtures } from './fixtures/generateFixtures.js'
+
+const size = process.argv[2] || 'medium'
+const iterations = Number(process.argv[3]) || 1000
+
+const baseOptions = {
+  cdataPropName: CDATA_PROP_NAME,
+  commentPropName: XML_COMMENT_PROP_NAME,
+  ignoreAttributes: false,
+  processEntities: false,
+}
+
+const parserOptions = {
+  ...baseOptions,
+  ignoreDeclaration: true,
+  numberParseOptions: { leadingZeros: false, hex: false },
+  parseAttributeValue: false,
+  parseTagValue: false,
+}
+
+const builderOptions = {
+  ...baseOptions,
+  format: true,
+  indentBy: XML_INDENT,
+  preserveOrder: true,
+}
+
+const config = {
+  conflictMarkerSize: 7,
+  ancestorConflictTag: 'base',
+  localConflictTag: 'ours',
+  otherConflictTag: 'theirs',
+}
+
+const fixtures = generateProfileFixtures(size)
+
+// biome-ignore lint/suspicious/noConsole: profiling output
+console.info(`Running ${iterations} iterations with ${size} fixtures...`)
+
+for (let i = 0; i < iterations; i++) {
+  const parser = new XMLParser(parserOptions)
+  const ancestorObj = parser.parse(fixtures.ancestor)
+  const localObj = parser.parse(fixtures.local)
+  const otherObj = parser.parse(fixtures.other)
+
+  const jsonMerger = new JsonMerger(config)
+  const mergedResult = jsonMerger.mergeThreeWay(ancestorObj, localObj, otherObj)
+
+  const builder = new XMLBuilder(builderOptions)
+  const mergedXml = builder.build(mergedResult.output)
+
+  if (mergedXml.length) {
+    const formatter = new ConflictMarkerFormatter(config)
+    let result = XML_DECL.concat(mergedXml)
+    result = formatter.handleSpecialEntities(result)
+    formatter.correctConflictIndent(result)
+  }
+}
+
+// biome-ignore lint/suspicious/noConsole: profiling output
+console.info('Done.')

--- a/test/perf/formatResults.mjs
+++ b/test/perf/formatResults.mjs
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+
+/**
+ * Converts Vitest bench JSON output to benchmark-action/github-action-benchmark format.
+ *
+ * Vitest bench JSON structure (v3.x):
+ * {
+ *   "files": [{
+ *     "filepath": "test/perf/merge.bench.ts",
+ *     "groups": [{
+ *       "fullName": "test/perf/merge.bench.ts > merge-small",
+ *       "benchmarks": [{
+ *         "name": "merge-small-no-conflict",
+ *         "hz": 1234.56,
+ *         "mean": 1.304,
+ *         "rme": 1.76,
+ *         ...
+ *       }]
+ *     }]
+ *   }]
+ * }
+ *
+ * benchmark-action customBiggerIsBetter format:
+ * [{ "name": "...", "unit": "ops/sec", "value": 1234, "range": "±1.2%" }]
+ *
+ * benchmark-action customSmallerIsBetter format:
+ * [{ "name": "...", "unit": "ms", "value": 0.81, "range": "±1.2%" }]
+ */
+
+const inputPath = 'perf-raw.json'
+const runtimeOutputPath = 'perf-runtime.json'
+const memoryOutputPath = 'perf-memory.json'
+
+const raw = JSON.parse(readFileSync(inputPath, 'utf-8'))
+
+const benchmarks = []
+
+for (const file of raw.files || []) {
+  for (const group of file.groups || []) {
+    for (const b of group.benchmarks || []) {
+      benchmarks.push(b)
+    }
+  }
+}
+
+const runtimeEntries = benchmarks.map(b => ({
+  name: b.name,
+  unit: 'ops/sec',
+  value: Math.round(b.hz),
+  range: `±${b.rme.toFixed(2)}%`,
+}))
+
+const memoryEntries = benchmarks.map(b => ({
+  name: b.name,
+  unit: 'ms',
+  value: Number(b.mean.toFixed(4)),
+  range: `±${b.rme.toFixed(2)}%`,
+}))
+
+writeFileSync(runtimeOutputPath, JSON.stringify(runtimeEntries, null, 2))
+writeFileSync(memoryOutputPath, JSON.stringify(memoryEntries, null, 2))
+
+// biome-ignore lint/suspicious/noConsole: reporting benchmark results
+console.info(
+  `Written ${runtimeEntries.length} runtime entries to ${runtimeOutputPath}`
+)
+// biome-ignore lint/suspicious/noConsole: reporting benchmark results
+console.info(
+  `Written ${memoryEntries.length} memory entries to ${memoryOutputPath}`
+)
+
+for (const entry of runtimeEntries) {
+  // biome-ignore lint/suspicious/noConsole: reporting benchmark results
+  console.info(`  ${entry.name}: ${entry.value} ${entry.unit} (${entry.range})`)
+}

--- a/test/perf/instrumentation/PhaseTimer.ts
+++ b/test/perf/instrumentation/PhaseTimer.ts
@@ -1,0 +1,48 @@
+import { performance } from 'node:perf_hooks'
+
+export class PhaseTimer {
+  private readonly id: string
+
+  constructor() {
+    this.id = String(performance.now())
+  }
+
+  startPhase(name: string): void {
+    performance.mark(this.markName(name, 'start'))
+  }
+
+  endPhase(name: string): void {
+    performance.mark(this.markName(name, 'end'))
+    performance.measure(
+      this.measureName(name),
+      this.markName(name, 'start'),
+      this.markName(name, 'end')
+    )
+  }
+
+  getTimings(): Record<string, number> {
+    const entries = performance.getEntriesByType('measure')
+    const prefix = `phase-${this.id}-`
+    const timings: Record<string, number> = {}
+    for (const entry of entries) {
+      if (entry.name.startsWith(prefix)) {
+        const phaseName = entry.name.slice(prefix.length)
+        timings[phaseName] = entry.duration
+      }
+    }
+    return timings
+  }
+
+  reset(): void {
+    performance.clearMarks()
+    performance.clearMeasures()
+  }
+
+  private markName(phase: string, point: string): string {
+    return `phase-${this.id}-${phase}-${point}`
+  }
+
+  private measureName(phase: string): string {
+    return `phase-${this.id}-${phase}`
+  }
+}

--- a/test/perf/instrumentation/instrumentedMerge.ts
+++ b/test/perf/instrumentation/instrumentedMerge.ts
@@ -1,0 +1,67 @@
+import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import { XML_DECL } from '../../../src/constant/parserConstant.js'
+import { ConflictMarkerFormatter } from '../../../src/merger/ConflictMarkerFormatter.js'
+import { JsonMerger } from '../../../src/merger/JsonMerger.js'
+import { builderOptions, parserOptions } from '../../../src/merger/XmlMerger.js'
+import type { MergeConfig } from '../../../src/types/conflictTypes.js'
+import type { PhaseTimer } from './PhaseTimer.js'
+
+const correctComments = (xml: string): string =>
+  xml.includes('<!--') ? xml.replace(/\s+<!--(.*?)-->\s+/g, '<!--$1-->') : xml
+
+export interface InstrumentedResult {
+  readonly output: string
+  readonly hasConflict: boolean
+  readonly inputSizeBytes: number
+  readonly outputSizeBytes: number
+}
+
+export const instrumentedMerge = (
+  ancestorContent: string,
+  localContent: string,
+  otherContent: string,
+  config: MergeConfig,
+  timer: PhaseTimer
+): InstrumentedResult => {
+  const inputSizeBytes =
+    Buffer.byteLength(ancestorContent) +
+    Buffer.byteLength(localContent) +
+    Buffer.byteLength(otherContent)
+
+  const parser = new XMLParser(parserOptions)
+
+  timer.startPhase('xml-parse')
+  const ancestorObj = parser.parse(ancestorContent)
+  const localObj = parser.parse(localContent)
+  const otherObj = parser.parse(otherContent)
+  timer.endPhase('xml-parse')
+
+  timer.startPhase('json-merge')
+  const jsonMerger = new JsonMerger(config)
+  const mergedResult = jsonMerger.mergeThreeWay(ancestorObj, localObj, otherObj)
+  timer.endPhase('json-merge')
+
+  timer.startPhase('xml-build')
+  const builder = new XMLBuilder(builderOptions)
+  const mergedXml: string = builder.build(mergedResult.output)
+  timer.endPhase('xml-build')
+
+  timer.startPhase('conflict-format')
+  let output = ''
+  if (mergedXml.length) {
+    const formatter = new ConflictMarkerFormatter(config)
+    let result = XML_DECL.concat(mergedXml)
+    result = formatter.handleSpecialEntities(result)
+    result = correctComments(result)
+    result = formatter.correctConflictIndent(result)
+    output = result
+  }
+  timer.endPhase('conflict-format')
+
+  return {
+    output,
+    hasConflict: mergedResult.hasConflict,
+    inputSizeBytes,
+    outputSizeBytes: Buffer.byteLength(output),
+  }
+}

--- a/test/perf/merge.bench.ts
+++ b/test/perf/merge.bench.ts
@@ -8,6 +8,7 @@ import {
 import type { MergeConfig } from '../../src/types/conflictTypes.js'
 import {
   generateOrderedFixtures,
+  generatePicklistFixtures,
   generateProfileFixtures,
 } from './fixtures/generateFixtures.js'
 import { instrumentedMerge } from './instrumentation/instrumentedMerge.js'
@@ -59,6 +60,21 @@ describe('merge-ordered', () => {
       ordered.ancestor,
       ordered.local,
       ordered.other,
+      config,
+      timer
+    )
+  })
+})
+
+describe('merge-picklist', () => {
+  const picklist = generatePicklistFixtures()
+
+  bench('merge-picklist-customfield', () => {
+    const timer = new PhaseTimer()
+    instrumentedMerge(
+      picklist.ancestor,
+      picklist.local,
+      picklist.other,
       config,
       timer
     )

--- a/test/perf/merge.bench.ts
+++ b/test/perf/merge.bench.ts
@@ -1,0 +1,66 @@
+import { bench, describe } from 'vitest'
+import {
+  DEFAULT_ANCESTOR_CONFLICT_TAG,
+  DEFAULT_CONFLICT_MARKER_SIZE,
+  DEFAULT_LOCAL_CONFLICT_TAG,
+  DEFAULT_OTHER_CONFLICT_TAG,
+} from '../../src/constant/conflictConstant.js'
+import type { MergeConfig } from '../../src/types/conflictTypes.js'
+import {
+  generateOrderedFixtures,
+  generateProfileFixtures,
+} from './fixtures/generateFixtures.js'
+import { instrumentedMerge } from './instrumentation/instrumentedMerge.js'
+import { PhaseTimer } from './instrumentation/PhaseTimer.js'
+
+const config: MergeConfig = {
+  conflictMarkerSize: DEFAULT_CONFLICT_MARKER_SIZE,
+  ancestorConflictTag: DEFAULT_ANCESTOR_CONFLICT_TAG,
+  localConflictTag: DEFAULT_LOCAL_CONFLICT_TAG,
+  otherConflictTag: DEFAULT_OTHER_CONFLICT_TAG,
+}
+
+const sizes = ['small', 'medium', 'large'] as const
+
+for (const size of sizes) {
+  const fixtures = generateProfileFixtures(size)
+
+  describe(`merge-${size}`, () => {
+    bench(`merge-${size}-no-conflict`, () => {
+      const timer = new PhaseTimer()
+      instrumentedMerge(
+        fixtures.ancestor,
+        fixtures.local,
+        fixtures.other,
+        config,
+        timer
+      )
+    })
+
+    bench(`merge-${size}-with-conflict`, () => {
+      const timer = new PhaseTimer()
+      instrumentedMerge(
+        fixtures.ancestor,
+        fixtures.conflictLocal,
+        fixtures.conflictOther,
+        config,
+        timer
+      )
+    })
+  })
+}
+
+describe('merge-ordered', () => {
+  const ordered = generateOrderedFixtures()
+
+  bench('merge-ordered-globalvalueset', () => {
+    const timer = new PhaseTimer()
+    instrumentedMerge(
+      ordered.ancestor,
+      ordered.local,
+      ordered.other,
+      config,
+      timer
+    )
+  })
+})

--- a/test/perf/phase.bench.ts
+++ b/test/perf/phase.bench.ts
@@ -1,0 +1,70 @@
+import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import { bench, describe } from 'vitest'
+import {
+  DEFAULT_ANCESTOR_CONFLICT_TAG,
+  DEFAULT_CONFLICT_MARKER_SIZE,
+  DEFAULT_LOCAL_CONFLICT_TAG,
+  DEFAULT_OTHER_CONFLICT_TAG,
+} from '../../src/constant/conflictConstant.js'
+import { XML_DECL } from '../../src/constant/parserConstant.js'
+import { ConflictMarkerFormatter } from '../../src/merger/ConflictMarkerFormatter.js'
+import { JsonMerger } from '../../src/merger/JsonMerger.js'
+import { builderOptions, parserOptions } from '../../src/merger/XmlMerger.js'
+import type { MergeConfig } from '../../src/types/conflictTypes.js'
+import { generateProfileFixtures } from './fixtures/generateFixtures.js'
+
+const config: MergeConfig = {
+  conflictMarkerSize: DEFAULT_CONFLICT_MARKER_SIZE,
+  ancestorConflictTag: DEFAULT_ANCESTOR_CONFLICT_TAG,
+  localConflictTag: DEFAULT_LOCAL_CONFLICT_TAG,
+  otherConflictTag: DEFAULT_OTHER_CONFLICT_TAG,
+}
+
+const sizes = ['small', 'medium', 'large'] as const
+
+for (const size of sizes) {
+  const fixtures = generateProfileFixtures(size)
+
+  const parser = new XMLParser(parserOptions)
+  const ancestorObj = parser.parse(fixtures.ancestor)
+  const localObj = parser.parse(fixtures.local)
+  const otherObj = parser.parse(fixtures.other)
+
+  const jsonMerger = new JsonMerger(config)
+  const mergedResult = jsonMerger.mergeThreeWay(ancestorObj, localObj, otherObj)
+
+  const builder = new XMLBuilder(builderOptions)
+  const mergedXml: string = builder.build(mergedResult.output)
+  const rawXml = XML_DECL.concat(mergedXml)
+
+  describe(`phase-parse-${size}`, () => {
+    bench(`parse-${size}`, () => {
+      const p = new XMLParser(parserOptions)
+      p.parse(fixtures.ancestor)
+      p.parse(fixtures.local)
+      p.parse(fixtures.other)
+    })
+  })
+
+  describe(`phase-merge-${size}`, () => {
+    bench(`merge-${size}`, () => {
+      const jm = new JsonMerger(config)
+      jm.mergeThreeWay(ancestorObj, localObj, otherObj)
+    })
+  })
+
+  describe(`phase-build-${size}`, () => {
+    bench(`build-${size}`, () => {
+      const b = new XMLBuilder(builderOptions)
+      b.build(mergedResult.output)
+    })
+  })
+
+  describe(`phase-format-${size}`, () => {
+    bench(`format-${size}`, () => {
+      const formatter = new ConflictMarkerFormatter(config)
+      formatter.handleSpecialEntities(rawXml)
+      formatter.correctConflictIndent(rawXml)
+    })
+  })
+}

--- a/test/perf/preview.mjs
+++ b/test/perf/preview.mjs
@@ -1,0 +1,114 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const runtime = JSON.parse(readFileSync('perf-runtime.json', 'utf-8'))
+const memory = JSON.parse(readFileSync('perf-memory.json', 'utf-8'))
+
+const mergeRuntime = runtime.filter(b => b.name.startsWith('merge-'))
+const phaseRuntime = runtime.filter(b => !b.name.startsWith('merge-'))
+
+const mergeMemory = memory.filter(b => b.name.startsWith('merge-'))
+const phaseMemory = memory.filter(b => !b.name.startsWith('merge-'))
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>sf-git-merge-driver — Performance Benchmarks</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; padding: 24px; }
+    h1 { font-size: 1.6rem; margin-bottom: 8px; color: #58a6ff; }
+    h2 { font-size: 1.2rem; margin: 32px 0 12px; color: #8b949e; border-bottom: 1px solid #21262d; padding-bottom: 8px; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px; }
+    .chart-box { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }
+    canvas { width: 100% !important; }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.85rem; }
+    th, td { padding: 6px 10px; text-align: left; border-bottom: 1px solid #21262d; }
+    th { color: #8b949e; font-weight: 600; }
+    td.val { font-family: 'SF Mono', Monaco, monospace; text-align: right; }
+    .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 24px; }
+  </style>
+</head>
+<body>
+  <h1>sf-git-merge-driver — Performance Benchmarks</h1>
+  <p class="subtitle">Local run — ${new Date().toISOString().slice(0, 19)}</p>
+
+  <div class="grid">
+    <div class="chart-box">
+      <h2>E2E Merge — Runtime (ops/sec, higher is better)</h2>
+      <canvas id="mergeRuntime"></canvas>
+    </div>
+    <div class="chart-box">
+      <h2>E2E Merge — Mean Time (ms, lower is better)</h2>
+      <canvas id="mergeMemory"></canvas>
+    </div>
+  </div>
+
+  <div class="grid">
+    <div class="chart-box">
+      <h2>Per-Phase — Runtime (ops/sec)</h2>
+      <canvas id="phaseRuntime"></canvas>
+    </div>
+    <div class="chart-box">
+      <h2>Per-Phase — Mean Time (ms)</h2>
+      <canvas id="phaseMemory"></canvas>
+    </div>
+  </div>
+
+  <h2>Raw Data</h2>
+  <div class="grid">
+    <div class="chart-box">
+      <h2>E2E Merge Benchmarks</h2>
+      <table>
+        <tr><th>Benchmark</th><th>ops/sec</th><th>Mean (ms)</th><th>Range</th></tr>
+        ${mergeRuntime.map((r, i) => `<tr><td>${r.name}</td><td class="val">${r.value.toLocaleString()}</td><td class="val">${mergeMemory[i].value}</td><td class="val">${r.range}</td></tr>`).join('\n        ')}
+      </table>
+    </div>
+    <div class="chart-box">
+      <h2>Per-Phase Benchmarks</h2>
+      <table>
+        <tr><th>Benchmark</th><th>ops/sec</th><th>Mean (ms)</th><th>Range</th></tr>
+        ${phaseRuntime.map((r, i) => `<tr><td>${r.name}</td><td class="val">${r.value.toLocaleString()}</td><td class="val">${phaseMemory[i].value}</td><td class="val">${r.range}</td></tr>`).join('\n        ')}
+      </table>
+    </div>
+  </div>
+
+  <script>
+    const colors = [
+      '#58a6ff','#3fb950','#d29922','#f85149','#bc8cff',
+      '#79c0ff','#56d364','#e3b341','#ff7b72','#d2a8ff',
+      '#39d353','#db6d28','#a5d6ff','#ffa657','#ff9bce',
+      '#7ee787','#f0883e','#6cb6ff','#d186eb','#ea6045'
+    ];
+    const chartOpts = (type) => ({
+      indexAxis: 'y',
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { type: type === 'log' ? 'logarithmic' : 'linear', grid: { color: '#21262d' }, ticks: { color: '#8b949e' } },
+        y: { grid: { display: false }, ticks: { color: '#c9d1d9', font: { size: 11 } } }
+      }
+    });
+    const bar = (id, labels, values, type) => {
+      new Chart(document.getElementById(id), {
+        type: 'bar',
+        data: { labels, datasets: [{ data: values, backgroundColor: labels.map((_, i) => colors[i % colors.length]), borderRadius: 4 }] },
+        options: chartOpts(type)
+      });
+    };
+
+    bar('mergeRuntime', ${JSON.stringify(mergeRuntime.map(b => b.name))}, ${JSON.stringify(mergeRuntime.map(b => b.value))}, 'log');
+    bar('mergeMemory',  ${JSON.stringify(mergeMemory.map(b => b.name))},  ${JSON.stringify(mergeMemory.map(b => b.value))}, 'log');
+    bar('phaseRuntime', ${JSON.stringify(phaseRuntime.map(b => b.name))}, ${JSON.stringify(phaseRuntime.map(b => b.value))}, 'log');
+    bar('phaseMemory',  ${JSON.stringify(phaseMemory.map(b => b.name))},  ${JSON.stringify(phaseMemory.map(b => b.value))}, 'log');
+  </script>
+</body>
+</html>`
+
+const outPath = 'perf-preview.html'
+writeFileSync(outPath, html)
+// biome-ignore lint/suspicious/noConsole: preview output
+console.info(`Preview written to ${outPath}`)
+execFileSync('open', [outPath])

--- a/test/perf/preview.mjs
+++ b/test/perf/preview.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
 
 const runtime = JSON.parse(readFileSync('perf-runtime.json', 'utf-8'))
@@ -111,4 +110,3 @@ const outPath = 'perf-preview.html'
 writeFileSync(outPath, html)
 // biome-ignore lint/suspicious/noConsole: preview output
 console.info(`Preview written to ${outPath}`)
-execFileSync('open', [outPath])

--- a/test/perf/preview.mjs
+++ b/test/perf/preview.mjs
@@ -1,13 +1,126 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ghPagesDir = process.argv[2] || ''
 
 const runtime = JSON.parse(readFileSync('perf-runtime.json', 'utf-8'))
 const memory = JSON.parse(readFileSync('perf-memory.json', 'utf-8'))
 
 const mergeRuntime = runtime.filter(b => b.name.startsWith('merge-'))
 const phaseRuntime = runtime.filter(b => !b.name.startsWith('merge-'))
-
 const mergeMemory = memory.filter(b => b.name.startsWith('merge-'))
 const phaseMemory = memory.filter(b => !b.name.startsWith('merge-'))
+
+const loadHistory = subdir => {
+  const dataPath = join(ghPagesDir, subdir, 'data.js')
+  if (!ghPagesDir || !existsSync(dataPath)) {
+    return []
+  }
+  const raw = readFileSync(dataPath, 'utf-8')
+  const jsonStr = raw.replace(/^window\.BENCHMARK_DATA\s*=\s*/, '')
+  const data = JSON.parse(jsonStr)
+  const suiteName = Object.keys(data.entries || {})[0]
+  return suiteName ? data.entries[suiteName] : []
+}
+
+const runtimeHistory = loadHistory('dev/bench/runtime')
+const memoryHistory = loadHistory('dev/bench/memory')
+const hasTrends = runtimeHistory.length > 0
+
+const buildTrendData = (history, currentBenches) => {
+  const benchNames = currentBenches.map(b => b.name)
+  const series = {}
+  for (const name of benchNames) {
+    series[name] = { labels: [], values: [] }
+  }
+
+  for (const entry of history) {
+    const label = entry.commit?.id?.slice(0, 7) || '?'
+    for (const b of entry.benches || []) {
+      if (series[b.name]) {
+        series[b.name].labels.push(label)
+        series[b.name].values.push(b.value)
+      }
+    }
+  }
+
+  for (const b of currentBenches) {
+    if (series[b.name]) {
+      series[b.name].labels.push('this PR')
+      series[b.name].values.push(b.value)
+    }
+  }
+
+  return series
+}
+
+const runtimeTrends = hasTrends ? buildTrendData(runtimeHistory, runtime) : {}
+const memoryTrends = hasTrends ? buildTrendData(memoryHistory, memory) : {}
+
+const trendChartsHtml = hasTrends
+  ? `
+  <h2>Trends — Runtime (ops/sec over time)</h2>
+  <div class="trend-grid">
+    ${runtime.map((b, i) => `<div class="chart-box trend-box"><h3>${b.name}</h3><canvas id="trend-rt-${i}"></canvas></div>`).join('\n    ')}
+  </div>
+
+  <h2>Trends — Mean Time (ms over time)</h2>
+  <div class="trend-grid">
+    ${memory.map((b, i) => `<div class="chart-box trend-box"><h3>${b.name}</h3><canvas id="trend-mem-${i}"></canvas></div>`).join('\n    ')}
+  </div>`
+  : ''
+
+const trendChartsJs = hasTrends
+  ? `
+    const runtimeTrends = ${JSON.stringify(runtimeTrends)};
+    const memoryTrends = ${JSON.stringify(memoryTrends)};
+    const runtimeNames = ${JSON.stringify(runtime.map(b => b.name))};
+    const memoryNames = ${JSON.stringify(memory.map(b => b.name))};
+
+    const trendOpts = (higherIsBetter) => ({
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { color: '#21262d' }, ticks: { color: '#8b949e', font: { size: 10 }, maxRotation: 45 } },
+        y: { grid: { color: '#21262d' }, ticks: { color: '#8b949e' } }
+      },
+      elements: {
+        point: { radius: 3, hoverRadius: 6 }
+      }
+    });
+
+    const trendLine = (id, labels, values, higherIsBetter) => {
+      const lastIdx = values.length - 1;
+      const pointBg = values.map((_, i) => i === lastIdx ? '#f85149' : '#58a6ff');
+      const pointRadius = values.map((_, i) => i === lastIdx ? 6 : 3);
+      new Chart(document.getElementById(id), {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [{
+            data: values,
+            borderColor: '#58a6ff',
+            backgroundColor: 'rgba(88,166,255,0.1)',
+            fill: true,
+            tension: 0.2,
+            pointBackgroundColor: pointBg,
+            pointRadius: pointRadius,
+            pointBorderColor: pointBg,
+          }]
+        },
+        options: trendOpts(higherIsBetter)
+      });
+    };
+
+    runtimeNames.forEach((name, i) => {
+      const t = runtimeTrends[name];
+      if (t) trendLine('trend-rt-' + i, t.labels, t.values, true);
+    });
+    memoryNames.forEach((name, i) => {
+      const t = memoryTrends[name];
+      if (t) trendLine('trend-mem-' + i, t.labels, t.values, false);
+    });`
+  : ''
 
 const html = `<!DOCTYPE html>
 <html lang="en">
@@ -20,8 +133,13 @@ const html = `<!DOCTYPE html>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; padding: 24px; }
     h1 { font-size: 1.6rem; margin-bottom: 8px; color: #58a6ff; }
     h2 { font-size: 1.2rem; margin: 32px 0 12px; color: #8b949e; border-bottom: 1px solid #21262d; padding-bottom: 8px; }
+    h3 { font-size: 0.9rem; color: #c9d1d9; margin-bottom: 8px; }
     .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px; }
+    .trend-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 16px; margin-bottom: 24px; }
     .chart-box { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }
+    .trend-box { min-height: 200px; }
+    .pr-dot { display: inline-block; width: 10px; height: 10px; background: #f85149; border-radius: 50%; margin-right: 6px; }
+    .legend-note { color: #8b949e; font-size: 0.85rem; margin-bottom: 16px; }
     canvas { width: 100% !important; }
     table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.85rem; }
     th, td { padding: 6px 10px; text-align: left; border-bottom: 1px solid #21262d; }
@@ -32,8 +150,12 @@ const html = `<!DOCTYPE html>
 </head>
 <body>
   <h1>sf-git-merge-driver — Performance Benchmarks</h1>
-  <p class="subtitle">Local run — ${new Date().toISOString().slice(0, 19)}</p>
+  <p class="subtitle">${hasTrends ? 'PR preview with historical trends' : 'Local run'} — ${new Date().toISOString().slice(0, 19)}</p>
+  ${hasTrends ? '<p class="legend-note"><span class="pr-dot"></span>Red dot = this PR</p>' : ''}
 
+  ${trendChartsHtml}
+
+  <h2>Current Run — Snapshot</h2>
   <div class="grid">
     <div class="chart-box">
       <h2>E2E Merge — Runtime (ops/sec, higher is better)</h2>
@@ -102,6 +224,8 @@ const html = `<!DOCTYPE html>
     bar('mergeMemory',  ${JSON.stringify(mergeMemory.map(b => b.name))},  ${JSON.stringify(mergeMemory.map(b => b.value))}, 'log');
     bar('phaseRuntime', ${JSON.stringify(phaseRuntime.map(b => b.name))}, ${JSON.stringify(phaseRuntime.map(b => b.value))}, 'log');
     bar('phaseMemory',  ${JSON.stringify(phaseMemory.map(b => b.name))},  ${JSON.stringify(phaseMemory.map(b => b.value))}, 'log');
+
+    ${trendChartsJs}
   </script>
 </body>
 </html>`
@@ -110,3 +234,9 @@ const outPath = 'perf-preview.html'
 writeFileSync(outPath, html)
 // biome-ignore lint/suspicious/noConsole: preview output
 console.info(`Preview written to ${outPath}`)
+if (hasTrends) {
+  // biome-ignore lint/suspicious/noConsole: preview output
+  console.info(
+    `Loaded ${runtimeHistory.length} historical data points from gh-pages`
+  )
+}

--- a/vitest.config.perf.ts
+++ b/vitest.config.perf.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    benchmark: {
+      outputJson: 'perf-raw.json',
+    },
+    include: ['test/perf/**/*.bench.ts'],
+  },
+})


### PR DESCRIPTION
# Explain your changes

---

Add a full performance testing and tracking infrastructure (Issue #13) to profile CPU, memory, and runtime across versions with GitHub Pages visualization.

**What's included:**

- **19 Vitest benchmarks** — 7 end-to-end merge scenarios (3 sizes × 2 conflict modes + ordered merge) and 12 per-phase micro-benchmarks (parse/merge/build/format × 3 sizes)
- **XML fixture generator** — Generates realistic Profile XML at 3 scales (small: ~50 fields, medium: ~500, large: ~2000) with conflict/non-conflict/ordered variants
- **Phase instrumentation** — Non-invasive `perf_hooks`-based timing for 4 merge phases (xml-parse, json-merge, xml-build, conflict-format) + I/O size tracking
- **Result formatter** — Converts Vitest bench JSON to `benchmark-action/github-action-benchmark` format (runtime as `customBiggerIsBetter`, memory as `customSmallerIsBetter`)
- **CI integration** — `perf` job in `on-main-push.yml` with dual benchmark-action steps (runtime at 130% alert threshold, memory at 150%) auto-pushing to `gh-pages`
- **Release tracking** — Version-tagged benchmarks in `on-published-release.yml` for cross-version performance comparison
- **Local flamegraph** — `flamegraph-runner.mjs` for on-demand 0x CPU profiling

**Architecture:** Library-level benchmarks calling `XmlMerger.mergeThreeWay()` directly (no oclif overhead) for stable, high ops/sec measurements.

**Manual step after merge:** Enable GitHub Pages on `gh-pages` branch in repo settings.

# Does this close any currently open issues?

---

closes #13

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

```bash
# Run all benchmarks (~17s)
npm run test:perf

# View results
cat perf-runtime.json  # ops/sec per benchmark
cat perf-memory.json   # mean time (ms) per benchmark

# Generate flamegraph (requires: npx 0x)
npx 0x -- node test/perf/flamegraph-runner.mjs small
```

# Any other comments

---

- Benchmarks are library-level (call `XmlMerger.mergeThreeWay()` directly) to avoid oclif bootstrap noise
- Phase instrumentation wraps XmlMerger externally — no production code changes beyond exporting parser/builder options
- `vitest` added as devDependency for benchmarks (aligns with planned Vitest migration)
- GitHub Pages will show two dashboards: runtime trends at `/dev/bench/runtime/` and memory trends at `/dev/bench/memory/`