### PR TITLE
chore: rename Memory benchmark to Latency benchmark

### DIFF
--- a/.github/workflows/reusable-perf.yml
+++ b/.github/workflows/reusable-perf.yml
@@ -56,10 +56,10 @@ jobs:
           alert-comment-cc-users: '@scolladon'
           benchmark-data-dir-path: dev/bench/runtime
 
-      - name: Memory benchmark
+      - name: Latency benchmark
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Memory Benchmark
+          name: Latency Benchmark
           tool: customSmallerIsBetter
           output-file-path: ./perf-memory.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/perf/formatResults.mjs
+++ b/test/perf/formatResults.mjs
@@ -66,7 +66,7 @@ console.info(
 )
 // biome-ignore lint/suspicious/noConsole: reporting benchmark results
 console.info(
-  `Written ${memoryEntries.length} memory entries to ${memoryOutputPath}`
+  `Written ${memoryEntries.length} latency entries to ${memoryOutputPath}`
 )
 
 for (const entry of runtimeEntries) {


### PR DESCRIPTION
## Summary
- Rename "Memory benchmark" → "Latency benchmark" in the perf workflow
- Rename "Memory Benchmark" → "Latency Benchmark" in github-action-benchmark name
- Update log messages from "memory" to "latency"

The step tracks mean execution time (ms/op), not memory usage.

## Test plan
- [ ] Perf job passes with renamed step