### PR TITLE
fix(install): idempotent install, --dry-run, --on-conflict handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ sf git merge driver install
 > **Upgrading from a previous version:** re-run `sf git merge driver install` in each repository after upgrading. Recent releases route conflicts through a bundled standalone binary (~80 ms per file instead of ~600 ms via the oclif command) — a 200-file rebase drops from ~120 s to ~16 s of merge-driver overhead. Previously-installed `.git/config` entries keep working via the retained oclif command, but do not receive the speedup until reinstall.
 >
 > Re-installing also wires git's `%S` placeholder into conflict markers: the ancestor-marker label now reflects git's own label (typically a short SHA) instead of the static `base` string. See the CHANGELOG for the exact before/after.
+>
+> **Safer install on upgrade.** If another merge driver is already configured on one of our metadata globs (e.g. a different Salesforce tool added its own `.git/info/attributes` line), install now aborts with a conflict report instead of silently stacking up. Use `--on-conflict=skip` to leave those globs alone, `--on-conflict=overwrite` (or `--force`) to take them over — in which case uninstall will restore the originals from an annotation comment. Add `--dry-run` to preview any install/uninstall plan before writing.
 
 ### Integration in VsCode SFDX-Hardis
 
@@ -315,7 +317,7 @@ git merge ...
 
 ## `sf git merge driver disable`
 
-Uninstalls the local git merge driver for the given org and branch.
+Uninstalls the local git merge driver from the current project.
 
 ```
 USAGE
@@ -330,11 +332,13 @@ GLOBAL FLAGS
   --json               Format output as json.
 
 DESCRIPTION
-  Uninstalls the local git merge driver for the given org and branch.
+  Uninstalls the local git merge driver from the current project.
 
-  Uninstalls the local git merge driver for the given org and branch, by removing the merge driver content in the
-  `.git/info/attributes` files in the project, deleting the merge driver configuration from the `.git/config` of the
-  project, and removing the installed binary from the node_modules/.bin directory.
+  Removes the `merge.salesforce-source` section from `.git/config` and strips the driver's rules from
+  `.git/info/attributes`. Lines that combined the driver with user attributes (e.g. `*.profile-meta.xml text=auto
+  merge=salesforce-source`) are rewritten to keep the user attributes; only the `merge=` token is removed. If a previous
+  install used `--on-conflict=overwrite`, the original driver rule is restored from the annotation comment written at
+  install time. `--dry-run` previews the plan without writing.
 
 ALIASES
   $ sf git merge driver disable
@@ -343,11 +347,15 @@ EXAMPLES
   Uninstall the driver for a given project:
 
     $ sf git merge driver disable
+
+  Preview the changes that would be written:
+
+    $ sf git merge driver disable --dry-run
 ```
 
 ## `sf git merge driver enable`
 
-Installs a local git merge driver for the given org and branch.
+Installs a local git merge driver for Salesforce metadata in the current project.
 
 ```
 USAGE
@@ -366,11 +374,16 @@ GLOBAL FLAGS
   --json               Format output as json.
 
 DESCRIPTION
-  Installs a local git merge driver for the given org and branch.
+  Installs a local git merge driver for Salesforce metadata in the current project.
 
-  Installs a local git merge driver for the given org and branch, by updating the `.git/info/attributes` files in the
-  project, creating a new merge driver configuration in the `.git/config` of the project, and installing the binary in
-  the node_modules/.bin directory.
+  Registers the driver in `.git/config` and adds one merge rule per Salesforce metadata glob to `.git/info/attributes`.
+  Safe to re-run: install is idempotent, preserves any user attributes already on the globs, and dedupes legacy
+  duplicate rules silently.
+
+  If another merge driver is already configured on one of our globs, install aborts by default and lists the conflicts.
+  Pass `--on-conflict=skip` to leave those globs to the other driver, `--on-conflict=overwrite` (or `--force`) to take
+  them over (uninstall restores the originals), or run the command from a TTY to be prompted interactively. `--dry-run`
+  previews the plan without writing.
 
 ALIASES
   $ sf git merge driver enable
@@ -379,11 +392,19 @@ EXAMPLES
   Install the driver for a given project:
 
     $ sf git merge driver enable
+
+  Preview the changes that would be written:
+
+    $ sf git merge driver enable --dry-run
+
+  Take over conflicting globs non-interactively (for CI):
+
+    $ sf git merge driver enable --force
 ```
 
 ## `sf git merge driver install`
 
-Installs a local git merge driver for the given org and branch.
+Installs a local git merge driver for Salesforce metadata in the current project.
 
 ```
 USAGE
@@ -403,11 +424,16 @@ GLOBAL FLAGS
   --json               Format output as json.
 
 DESCRIPTION
-  Installs a local git merge driver for the given org and branch.
+  Installs a local git merge driver for Salesforce metadata in the current project.
 
-  Installs a local git merge driver for the given org and branch, by updating the `.git/info/attributes` files in the
-  project, creating a new merge driver configuration in the `.git/config` of the project, and installing the binary in
-  the node_modules/.bin directory.
+  Registers the driver in `.git/config` and adds one merge rule per Salesforce metadata glob to `.git/info/attributes`.
+  Safe to re-run: install is idempotent, preserves any user attributes already on the globs, and dedupes legacy
+  duplicate rules silently.
+
+  If another merge driver is already configured on one of our globs, install aborts by default and lists the conflicts.
+  Pass `--on-conflict=skip` to leave those globs to the other driver, `--on-conflict=overwrite` (or `--force`) to take
+  them over (uninstall restores the originals), or run the command from a TTY to be prompted interactively. `--dry-run`
+  previews the plan without writing.
 
 ALIASES
   $ sf git merge driver enable
@@ -416,9 +442,17 @@ EXAMPLES
   Install the driver for a given project:
 
     $ sf git merge driver install
+
+  Preview the changes that would be written:
+
+    $ sf git merge driver install --dry-run
+
+  Take over conflicting globs non-interactively (for CI):
+
+    $ sf git merge driver install --force
 ```
 
-_See code: [src/commands/git/merge/driver/install.ts](https://github.com/scolladon/sf-git-merge-driver/blob/main/src/commands/git/merge/driver/install.ts)_
+_See code: [src/commands/git/merge/driver/install.ts](https://github.com/scolladon/sf-git-merge-driver/blob/v1.6.1/src/commands/git/merge/driver/install.ts)_
 
 ## `sf git merge driver run`
 
@@ -465,11 +499,11 @@ EXAMPLES
   - output-file is the path to the file where the merged content will be written
 ```
 
-_See code: [src/commands/git/merge/driver/run.ts](https://github.com/scolladon/sf-git-merge-driver/blob/main/src/commands/git/merge/driver/run.ts)_
+_See code: [src/commands/git/merge/driver/run.ts](https://github.com/scolladon/sf-git-merge-driver/blob/v1.6.1/src/commands/git/merge/driver/run.ts)_
 
 ## `sf git merge driver uninstall`
 
-Uninstalls the local git merge driver for the given org and branch.
+Uninstalls the local git merge driver from the current project.
 
 ```
 USAGE
@@ -484,11 +518,13 @@ GLOBAL FLAGS
   --json               Format output as json.
 
 DESCRIPTION
-  Uninstalls the local git merge driver for the given org and branch.
+  Uninstalls the local git merge driver from the current project.
 
-  Uninstalls the local git merge driver for the given org and branch, by removing the merge driver content in the
-  `.git/info/attributes` files in the project, deleting the merge driver configuration from the `.git/config` of the
-  project, and removing the installed binary from the node_modules/.bin directory.
+  Removes the `merge.salesforce-source` section from `.git/config` and strips the driver's rules from
+  `.git/info/attributes`. Lines that combined the driver with user attributes (e.g. `*.profile-meta.xml text=auto
+  merge=salesforce-source`) are rewritten to keep the user attributes; only the `merge=` token is removed. If a previous
+  install used `--on-conflict=overwrite`, the original driver rule is restored from the annotation comment written at
+  install time. `--dry-run` previews the plan without writing.
 
 ALIASES
   $ sf git merge driver disable
@@ -497,9 +533,13 @@ EXAMPLES
   Uninstall the driver for a given project:
 
     $ sf git merge driver uninstall
+
+  Preview the changes that would be written:
+
+    $ sf git merge driver uninstall --dry-run
 ```
 
-_See code: [src/commands/git/merge/driver/uninstall.ts](https://github.com/scolladon/sf-git-merge-driver/blob/main/src/commands/git/merge/driver/uninstall.ts)_
+_See code: [src/commands/git/merge/driver/uninstall.ts](https://github.com/scolladon/sf-git-merge-driver/blob/v1.6.1/src/commands/git/merge/driver/uninstall.ts)_
 <!-- commandsstop -->
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -319,7 +319,11 @@ Uninstalls the local git merge driver for the given org and branch.
 
 ```
 USAGE
-  $ sf git merge driver disable [--json] [--flags-dir <value>]
+  $ sf git merge driver disable [--json] [--flags-dir <value>] [--dry-run]
+
+FLAGS
+  --dry-run  Plan the uninstall without touching git config or .git/info/attributes. Exits 0; shows what would be
+             removed.
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.
@@ -347,7 +351,15 @@ Installs a local git merge driver for the given org and branch.
 
 ```
 USAGE
-  $ sf git merge driver enable [--json] [--flags-dir <value>]
+  $ sf git merge driver enable [--json] [--flags-dir <value>] [--dry-run] [--on-conflict abort|skip|overwrite] [--force]
+
+FLAGS
+  --dry-run               Plan the install without writing to git config or .git/info/attributes. Exits 0; shows the
+                          list of rules that would be added/skipped/conflict.
+  --force                 Alias for --on-conflict=overwrite. Non-interactive shortcut for CI.
+  --on-conflict=<option>  [default: abort] How to handle patterns already owned by another merge driver in
+                          .git/info/attributes. Default: abort (refuse to change anything).
+                          <options: abort|skip|overwrite>
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.
@@ -375,7 +387,16 @@ Installs a local git merge driver for the given org and branch.
 
 ```
 USAGE
-  $ sf git merge driver install [--json] [--flags-dir <value>]
+  $ sf git merge driver install [--json] [--flags-dir <value>] [--dry-run] [--on-conflict abort|skip|overwrite]
+  [--force]
+
+FLAGS
+  --dry-run               Plan the install without writing to git config or .git/info/attributes. Exits 0; shows the
+                          list of rules that would be added/skipped/conflict.
+  --force                 Alias for --on-conflict=overwrite. Non-interactive shortcut for CI.
+  --on-conflict=<option>  [default: abort] How to handle patterns already owned by another merge driver in
+                          .git/info/attributes. Default: abort (refuse to change anything).
+                          <options: abort|skip|overwrite>
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.
@@ -452,7 +473,11 @@ Uninstalls the local git merge driver for the given org and branch.
 
 ```
 USAGE
-  $ sf git merge driver uninstall [--json] [--flags-dir <value>]
+  $ sf git merge driver uninstall [--json] [--flags-dir <value>] [--dry-run]
+
+FLAGS
+  --dry-run  Plan the uninstall without touching git config or .git/info/attributes. Exits 0; shows what would be
+             removed.
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ sf git merge driver install
 >
 > Re-installing also wires git's `%S` placeholder into conflict markers: the ancestor-marker label now reflects git's own label (typically a short SHA) instead of the static `base` string. See the CHANGELOG for the exact before/after.
 >
-> **Safer install on upgrade.** If another merge driver is already configured on one of our metadata globs (e.g. a different Salesforce tool added its own `.git/info/attributes` line), install now aborts with a conflict report instead of silently stacking up. Use `--on-conflict=skip` to leave those globs alone, `--on-conflict=overwrite` (or `--force`) to take them over — in which case uninstall will restore the originals from an annotation comment. Add `--dry-run` to preview any install/uninstall plan before writing.
+> **Safe install on upgrade.** If another merge driver is already configured on one of our metadata globs (e.g. a different Salesforce tool added its own `.git/info/attributes` line), install now aborts with a conflict report instead of silently stacking up. Use `--on-conflict=skip` to leave those globs alone, `--on-conflict=overwrite` (or `--force`) to take them over — in which case uninstall will restore the originals from an annotation comment. Add `--dry-run` to preview any install/uninstall plan before writing.
 
 ### Integration in VsCode SFDX-Hardis
 
@@ -452,7 +452,7 @@ EXAMPLES
     $ sf git merge driver install --force
 ```
 
-_See code: [src/commands/git/merge/driver/install.ts](https://github.com/scolladon/sf-git-merge-driver/blob/v1.6.1/src/commands/git/merge/driver/install.ts)_
+_See code: [src/commands/git/merge/driver/install.ts](https://github.com/scolladon/sf-git-merge-driver/blob/main/src/commands/git/merge/driver/install.ts)_
 
 ## `sf git merge driver run`
 
@@ -499,7 +499,7 @@ EXAMPLES
   - output-file is the path to the file where the merged content will be written
 ```
 
-_See code: [src/commands/git/merge/driver/run.ts](https://github.com/scolladon/sf-git-merge-driver/blob/v1.6.1/src/commands/git/merge/driver/run.ts)_
+_See code: [src/commands/git/merge/driver/run.ts](https://github.com/scolladon/sf-git-merge-driver/blob/main/src/commands/git/merge/driver/run.ts)_
 
 ## `sf git merge driver uninstall`
 
@@ -539,7 +539,7 @@ EXAMPLES
     $ sf git merge driver uninstall --dry-run
 ```
 
-_See code: [src/commands/git/merge/driver/uninstall.ts](https://github.com/scolladon/sf-git-merge-driver/blob/v1.6.1/src/commands/git/merge/driver/uninstall.ts)_
+_See code: [src/commands/git/merge/driver/uninstall.ts](https://github.com/scolladon/sf-git-merge-driver/blob/main/src/commands/git/merge/driver/uninstall.ts)_
 <!-- commandsstop -->
 
 ## Changelog

--- a/messages/install.md
+++ b/messages/install.md
@@ -21,3 +21,15 @@ If another merge driver is already configured on one of our globs, install abort
 - Take over conflicting globs non-interactively (for CI):
 
   <%= config.bin %> <%= command.id %> --force
+
+# flags.dry-run.summary
+
+Plan the install without writing to git config or .git/info/attributes. Exits 0; shows the list of rules that would be added/skipped/conflict.
+
+# flags.on-conflict.summary
+
+How to handle patterns already owned by another merge driver in .git/info/attributes. Default: abort (refuse to change anything).
+
+# flags.force.summary
+
+Alias for --on-conflict=overwrite. Non-interactive shortcut for CI.

--- a/messages/install.md
+++ b/messages/install.md
@@ -1,13 +1,23 @@
 # summary
 
-Installs a local git merge driver for the given org and branch.
+Installs a local git merge driver for Salesforce metadata in the current project.
 
 # description
 
-Installs a local git merge driver for the given org and branch, by updating the `.git/info/attributes` files in the project, creating a new merge driver configuration in the `.git/config` of the project, and installing the binary in the node_modules/.bin directory.
+Registers the driver in `.git/config` and adds one merge rule per Salesforce metadata glob to `.git/info/attributes`. Safe to re-run: install is idempotent, preserves any user attributes already on the globs, and dedupes legacy duplicate rules silently.
+
+If another merge driver is already configured on one of our globs, install aborts by default and lists the conflicts. Pass `--on-conflict=skip` to leave those globs to the other driver, `--on-conflict=overwrite` (or `--force`) to take them over (uninstall restores the originals), or run the command from a TTY to be prompted interactively. `--dry-run` previews the plan without writing.
 
 # examples
 
 - Install the driver for a given project:
 
   <%= config.bin %> <%= command.id %>
+
+- Preview the changes that would be written:
+
+  <%= config.bin %> <%= command.id %> --dry-run
+
+- Take over conflicting globs non-interactively (for CI):
+
+  <%= config.bin %> <%= command.id %> --force

--- a/messages/uninstall.md
+++ b/messages/uninstall.md
@@ -1,13 +1,17 @@
 # summary
 
-Uninstalls the local git merge driver for the given org and branch.
+Uninstalls the local git merge driver from the current project.
 
 # description
 
-Uninstalls the local git merge driver for the given org and branch, by removing the merge driver content in the `.git/info/attributes` files in the project, deleting the merge driver configuration from the `.git/config` of the project, and removing the installed binary from the node_modules/.bin directory.
+Removes the `merge.salesforce-source` section from `.git/config` and strips the driver's rules from `.git/info/attributes`. Lines that combined the driver with user attributes (e.g. `*.profile-meta.xml text=auto merge=salesforce-source`) are rewritten to keep the user attributes; only the `merge=` token is removed. If a previous install used `--on-conflict=overwrite`, the original driver rule is restored from the annotation comment written at install time. `--dry-run` previews the plan without writing.
 
 # examples
 
 - Uninstall the driver for a given project:
 
   <%= config.bin %> <%= command.id %>
+
+- Preview the changes that would be written:
+
+  <%= config.bin %> <%= command.id %> --dry-run

--- a/messages/uninstall.md
+++ b/messages/uninstall.md
@@ -15,3 +15,7 @@ Removes the `merge.salesforce-source` section from `.git/config` and strips the 
 - Preview the changes that would be written:
 
   <%= config.bin %> <%= command.id %> --dry-run
+
+# flags.dry-run.summary
+
+Plan the uninstall without touching git config or .git/info/attributes. Exits 0; shows what would be removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1646,9 +1646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1666,9 +1663,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1686,9 +1680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1706,9 +1697,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -4470,9 +4458,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4490,9 +4475,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4510,9 +4492,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4530,9 +4509,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4550,9 +4526,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4570,9 +4543,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4590,9 +4560,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4610,9 +4577,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4823,9 +4787,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4840,9 +4801,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4857,9 +4815,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4874,9 +4829,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4891,9 +4843,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4908,9 +4857,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4925,9 +4871,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4942,9 +4885,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5179,9 +5119,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5199,9 +5136,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5219,9 +5153,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5239,9 +5170,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5259,9 +5187,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5279,9 +5204,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10366,9 +10288,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10390,9 +10309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10414,9 +10330,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10438,9 +10351,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -1,3 +1,4 @@
+import { createInterface } from 'node:readline'
 import { Messages } from '@salesforce/core'
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
 import { DRIVER_NAME } from '../../../../constant/driverConstant.js'
@@ -12,6 +13,46 @@ import {
 } from '../../../../service/InstallService.js'
 import { log } from '../../../../utils/LoggingDecorator.js'
 import { Logger } from '../../../../utils/LoggingService.js'
+
+type PolicyPrompt = (
+  conflicts: readonly {
+    pattern: string
+    existingDriver: string
+  }[]
+) => Promise<ConflictPolicy>
+
+/**
+ * Ask the user on stdin how to handle conflicts. Invoked only when
+ * `--on-conflict` is unset AND stdout is a TTY AND the planner emitted
+ * conflict actions. Kept as a dependency-injectable function so tests
+ * can drive the command without opening a real readline.
+ */
+const defaultPolicyPrompt: PolicyPrompt = async conflicts => {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    process.stdout.write(
+      `\n${conflicts.length} pattern(s) already configured with a different merge driver:\n`
+    )
+    for (const c of conflicts) {
+      process.stdout.write(`  ${c.pattern} → merge=${c.existingDriver}\n`)
+    }
+    process.stdout.write(
+      '\nHow should we proceed?\n' +
+        '  [a] abort     (safe, no changes)\n' +
+        '  [s] skip      (leave those globs with the other driver)\n' +
+        '  [o] overwrite (replace; uninstall will restore)\n'
+    )
+    const answer = await new Promise<string>(resolve => {
+      rl.question('Enter a / s / o [a]: ', resolve)
+    })
+    const normalised = answer.trim().toLowerCase()
+    if (normalised === 's' || normalised === 'skip') return 'skip'
+    if (normalised === 'o' || normalised === 'overwrite') return 'overwrite'
+    return 'abort'
+  } finally {
+    rl.close()
+  }
+}
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
 const messages = Messages.loadMessages(PLUGIN_NAME, 'install')
@@ -125,13 +166,56 @@ export default class Install extends SfCommand<void> {
     }),
   }
 
+  /**
+   * Hook for tests — overrides the interactive prompt implementation.
+   * Kept protected so test doubles can swap in without going through
+   * readline. In production, stdout-isTTY is the gate; in tests the
+   * caller supplies a stub.
+   */
+  protected promptPolicy: PolicyPrompt = defaultPolicyPrompt
+
+  /**
+   * True when the interactive policy prompt should run: `--on-conflict`
+   * unset (still 'abort' default), `--force` unset, stdout is a TTY.
+   * Non-TTY (CI) invocations without the flag keep the strict abort
+   * default so nothing surprising happens in automation.
+   */
+  private shouldPromptForPolicy(flags: {
+    'on-conflict': ConflictPolicy
+    force: boolean
+    'dry-run': boolean
+  }): boolean {
+    if (flags['dry-run']) return false
+    if (flags.force) return false
+    if (flags['on-conflict'] !== 'abort') return false
+    return Boolean(process.stdout.isTTY)
+  }
+
   @log('Install')
   public async run(): Promise<void> {
     const { flags } = await this.parse(Install)
     const dryRun = flags['dry-run']
-    const onConflict: ConflictPolicy = flags.force
+
+    // First pass: use the requested policy directly unless we need to
+    // surface conflicts to a human first.
+    let onConflict: ConflictPolicy = flags.force
       ? 'overwrite'
       : flags['on-conflict']
+
+    if (this.shouldPromptForPolicy(flags)) {
+      // Run a cheap dry-run first so we know whether to prompt at all.
+      const preview = await new InstallService().installMergeDriver({
+        dryRun: true,
+      })
+      const conflicts = preview.plan.actions.flatMap(a =>
+        a.kind === 'conflict'
+          ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+          : []
+      )
+      if (conflicts.length > 0) {
+        onConflict = await this.promptPolicy(conflicts)
+      }
+    }
 
     try {
       const outcome = await new InstallService().installMergeDriver({

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -1,8 +1,12 @@
 import { Messages } from '@salesforce/core'
-import { SfCommand } from '@salesforce/sf-plugins-core'
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
+import { DRIVER_NAME } from '../../../../constant/driverConstant.js'
 import { PLUGIN_NAME } from '../../../../constant/pluginConstant.js'
 import {
+  DRIVER_COMMAND,
+  DRIVER_NAME_CONFIG_VALUE,
   InstallConflictError,
+  type InstallOutcome,
   InstallService,
 } from '../../../../service/InstallService.js'
 import { log } from '../../../../utils/LoggingDecorator.js'
@@ -10,6 +14,53 @@ import { Logger } from '../../../../utils/LoggingService.js'
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
 const messages = Messages.loadMessages(PLUGIN_NAME, 'install')
+
+const SAMPLE_COUNT = 5
+
+const formatDryRunReport = (outcome: InstallOutcome): string => {
+  const { plan, gitAttributesPath } = outcome
+  const adds = plan.actions.filter(a => a.kind === 'add')
+  const skips = plan.actions.filter(a => a.kind === 'skip')
+  const conflicts = plan.actions.flatMap(a =>
+    a.kind === 'conflict'
+      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+      : []
+  )
+  const dedupCount = plan.dedupDrops.length
+
+  const lines: string[] = []
+  lines.push('DRY RUN — no changes applied.')
+  lines.push('')
+  lines.push('git config:')
+  lines.push(
+    `  would set merge.${DRIVER_NAME}.name = "${DRIVER_NAME_CONFIG_VALUE}"`
+  )
+  lines.push(`  would set merge.${DRIVER_NAME}.driver = ${DRIVER_COMMAND}`)
+  lines.push('')
+  lines.push(`${gitAttributesPath}:`)
+  lines.push(`  ${adds.length} rule(s) would be added`)
+  if (adds.length > 0) {
+    const preview = adds
+      .slice(0, SAMPLE_COUNT)
+      .map(a => a.pattern)
+      .join(', ')
+    const more =
+      adds.length > SAMPLE_COUNT ? `, … ${adds.length - SAMPLE_COUNT} more` : ''
+    lines.push(`    ${preview}${more}`)
+  }
+  lines.push(`  ${skips.length} rule(s) already present (skipped)`)
+  lines.push(`  ${dedupCount} legacy duplicate line(s) would be removed`)
+  if (conflicts.length > 0) {
+    lines.push('')
+    lines.push(
+      `⚠ ${conflicts.length} conflict(s) — installation would abort without --on-conflict=skip|overwrite (planned for a later step):`
+    )
+    for (const c of conflicts) {
+      lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
+    }
+  }
+  return lines.join('\n')
+}
 
 export default class Install extends SfCommand<void> {
   public static override readonly summary = messages.getMessage('summary')
@@ -20,25 +71,30 @@ export default class Install extends SfCommand<void> {
     messages.getMessage('description')
   public static override readonly examples = messages.getMessages('examples')
 
-  public static override readonly flags = {}
+  public static override readonly flags = {
+    'dry-run': Flags.boolean({
+      summary:
+        'Plan the install without writing to git config or .git/info/attributes. Exits 0; shows the list of rules that would be added/skipped/conflict.',
+      default: false,
+    }),
+  }
 
   @log('Install')
   public async run(): Promise<void> {
-    // `InstallService` is now idempotent by plan: re-running it reads the
-    // attributes file, compares against the desired pattern set, and only
-    // writes when something is missing. No need for the previous
-    // "uninstall first, then append" dance — that pattern destroyed user
-    // attributes on combined lines and always emitted a stray uninstall
-    // error on fresh installs.
+    const { flags } = await this.parse(Install)
+    const dryRun = flags['dry-run']
+
     try {
-      await new InstallService().installMergeDriver()
+      const outcome = await new InstallService().installMergeDriver({
+        dryRun,
+      })
+      if (dryRun) {
+        this.log(formatDryRunReport(outcome))
+        return
+      }
       Logger.info('Merge driver installed successfully')
     } catch (error) {
       if (error instanceof InstallConflictError) {
-        // Conflicts are a user-actionable state, not a crash — surface
-        // the list and exit non-zero. Step 5 adds --on-conflict to let
-        // users pick skip/overwrite semantics instead of the default
-        // strict abort.
         this.error(error.message, { exit: 2 })
       }
       throw error

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -2,6 +2,7 @@ import { Messages } from '@salesforce/core'
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
 import { DRIVER_NAME } from '../../../../constant/driverConstant.js'
 import { PLUGIN_NAME } from '../../../../constant/pluginConstant.js'
+import type { ConflictPolicy } from '../../../../service/GitAttributesPlanner.js'
 import {
   DRIVER_COMMAND,
   DRIVER_NAME_CONFIG_VALUE,
@@ -23,6 +24,16 @@ const formatDryRunReport = (outcome: InstallOutcome): string => {
   const skips = plan.actions.filter(a => a.kind === 'skip')
   const conflicts = plan.actions.flatMap(a =>
     a.kind === 'conflict'
+      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+      : []
+  )
+  const skippedConflicts = plan.actions.flatMap(a =>
+    a.kind === 'skip-conflict'
+      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+      : []
+  )
+  const overwrites = plan.actions.flatMap(a =>
+    a.kind === 'overwrite'
       ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
       : []
   )
@@ -50,10 +61,28 @@ const formatDryRunReport = (outcome: InstallOutcome): string => {
   }
   lines.push(`  ${skips.length} rule(s) already present (skipped)`)
   lines.push(`  ${dedupCount} legacy duplicate line(s) would be removed`)
+  if (skippedConflicts.length > 0) {
+    lines.push('')
+    lines.push(
+      `${skippedConflicts.length} conflict(s) left to their current driver (--on-conflict=skip):`
+    )
+    for (const c of skippedConflicts) {
+      lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
+    }
+  }
+  if (overwrites.length > 0) {
+    lines.push('')
+    lines.push(
+      `${overwrites.length} conflict(s) would be overwritten (--on-conflict=overwrite); uninstall will restore them:`
+    )
+    for (const c of overwrites) {
+      lines.push(`    ${c.pattern} (was merge=${c.existingDriver})`)
+    }
+  }
   if (conflicts.length > 0) {
     lines.push('')
     lines.push(
-      `⚠ ${conflicts.length} conflict(s) — installation would abort without --on-conflict=skip|overwrite (planned for a later step):`
+      `⚠ ${conflicts.length} conflict(s) — installation would abort. Re-run with --on-conflict=skip or --on-conflict=overwrite (or --force) to proceed:`
     )
     for (const c of conflicts) {
       lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
@@ -61,6 +90,12 @@ const formatDryRunReport = (outcome: InstallOutcome): string => {
   }
   return lines.join('\n')
 }
+
+const CONFLICT_POLICIES: readonly ConflictPolicy[] = [
+  'abort',
+  'skip',
+  'overwrite',
+]
 
 export default class Install extends SfCommand<void> {
   public static override readonly summary = messages.getMessage('summary')
@@ -77,16 +112,31 @@ export default class Install extends SfCommand<void> {
         'Plan the install without writing to git config or .git/info/attributes. Exits 0; shows the list of rules that would be added/skipped/conflict.',
       default: false,
     }),
+    'on-conflict': Flags.option({
+      summary:
+        'How to handle patterns already owned by another merge driver in .git/info/attributes. Default: abort (refuse to change anything).',
+      options: CONFLICT_POLICIES,
+      default: 'abort' as ConflictPolicy,
+    })(),
+    force: Flags.boolean({
+      summary:
+        'Alias for --on-conflict=overwrite. Non-interactive shortcut for CI.',
+      default: false,
+    }),
   }
 
   @log('Install')
   public async run(): Promise<void> {
     const { flags } = await this.parse(Install)
     const dryRun = flags['dry-run']
+    const onConflict: ConflictPolicy = flags.force
+      ? 'overwrite'
+      : flags['on-conflict']
 
     try {
       const outcome = await new InstallService().installMergeDriver({
         dryRun,
+        onConflict,
       })
       if (dryRun) {
         this.log(formatDryRunReport(outcome))

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -83,19 +83,16 @@ export default class Install extends SfCommand<void> {
 
   public static override readonly flags = {
     'dry-run': Flags.boolean({
-      summary:
-        'Plan the install without writing to git config or .git/info/attributes. Exits 0; shows the list of rules that would be added/skipped/conflict.',
+      summary: messages.getMessage('flags.dry-run.summary'),
       default: false,
     }),
     'on-conflict': Flags.option({
-      summary:
-        'How to handle patterns already owned by another merge driver in .git/info/attributes. Default: abort (refuse to change anything).',
+      summary: messages.getMessage('flags.on-conflict.summary'),
       options: CONFLICT_POLICIES,
       default: 'abort' as ConflictPolicy,
     })(),
     force: Flags.boolean({
-      summary:
-        'Alias for --on-conflict=overwrite. Non-interactive shortcut for CI.',
+      summary: messages.getMessage('flags.force.summary'),
       default: false,
     }),
   }

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -1,12 +1,13 @@
 import { createInterface } from 'node:readline'
 import { Messages } from '@salesforce/core'
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
-import { DRIVER_NAME } from '../../../../constant/driverConstant.js'
 import { PLUGIN_NAME } from '../../../../constant/pluginConstant.js'
 import type { ConflictPolicy } from '../../../../service/GitAttributesPlanner.js'
 import {
-  DRIVER_COMMAND,
-  DRIVER_NAME_CONFIG_VALUE,
+  formatInstallDryRunReport,
+  shouldPromptForPolicy,
+} from '../../../../service/InstallReports.js'
+import {
   InstallConflictError,
   type InstallOutcome,
   InstallService,
@@ -22,10 +23,9 @@ type PolicyPrompt = (
 ) => Promise<ConflictPolicy>
 
 /**
- * Ask the user on stdin how to handle conflicts. Invoked only when
- * `--on-conflict` is unset AND stdout is a TTY AND the planner emitted
- * conflict actions. Kept as a dependency-injectable function so tests
- * can drive the command without opening a real readline.
+ * Map a raw terminal answer to a `ConflictPolicy`. Pure — exported so
+ * the answer classifier can be table-tested directly (tight feedback
+ * loop for mutation testing); also used by `defaultPolicyPrompt` below.
  */
 export const parsePromptAnswer = (raw: string): ConflictPolicy => {
   const normalised = raw.trim().toLowerCase()
@@ -65,99 +65,6 @@ const defaultPolicyPrompt: PolicyPrompt = async conflicts => {
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
 const messages = Messages.loadMessages(PLUGIN_NAME, 'install')
-
-const SAMPLE_COUNT = 5
-
-const formatDryRunReport = (outcome: InstallOutcome): string => {
-  const { plan, gitAttributesPath } = outcome
-  const adds = plan.actions.filter(a => a.kind === 'add')
-  const skips = plan.actions.filter(a => a.kind === 'skip')
-  const conflicts = plan.actions.flatMap(a =>
-    a.kind === 'conflict'
-      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
-      : []
-  )
-  const skippedConflicts = plan.actions.flatMap(a =>
-    a.kind === 'skip-conflict'
-      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
-      : []
-  )
-  const overwrites = plan.actions.flatMap(a =>
-    a.kind === 'overwrite'
-      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
-      : []
-  )
-  const dedupCount = plan.dedupDrops.length
-
-  const lines: string[] = []
-  lines.push('DRY RUN — no changes applied.')
-  lines.push('')
-  lines.push('git config:')
-  lines.push(
-    `  would set merge.${DRIVER_NAME}.name = "${DRIVER_NAME_CONFIG_VALUE}"`
-  )
-  lines.push(`  would set merge.${DRIVER_NAME}.driver = ${DRIVER_COMMAND}`)
-  lines.push('')
-  lines.push(`${gitAttributesPath}:`)
-  lines.push(`  ${adds.length} rule(s) would be added`)
-  if (adds.length > 0) {
-    const preview = adds
-      .slice(0, SAMPLE_COUNT)
-      .map(a => a.pattern)
-      .join(', ')
-    const more =
-      adds.length > SAMPLE_COUNT ? `, … ${adds.length - SAMPLE_COUNT} more` : ''
-    lines.push(`    ${preview}${more}`)
-  }
-  lines.push(`  ${skips.length} rule(s) already present (skipped)`)
-  lines.push(`  ${dedupCount} legacy duplicate line(s) would be removed`)
-  if (skippedConflicts.length > 0) {
-    lines.push('')
-    lines.push(
-      `${skippedConflicts.length} conflict(s) left to their current driver (--on-conflict=skip):`
-    )
-    for (const c of skippedConflicts) {
-      lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
-    }
-  }
-  if (overwrites.length > 0) {
-    lines.push('')
-    lines.push(
-      `${overwrites.length} conflict(s) would be overwritten (--on-conflict=overwrite); uninstall will restore them:`
-    )
-    for (const c of overwrites) {
-      lines.push(`    ${c.pattern} (was merge=${c.existingDriver})`)
-    }
-  }
-  if (conflicts.length > 0) {
-    lines.push('')
-    lines.push(
-      `⚠ ${conflicts.length} conflict(s) — installation would abort. Re-run with --on-conflict=skip or --on-conflict=overwrite (or --force) to proceed:`
-    )
-    for (const c of conflicts) {
-      lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
-    }
-  }
-  if (plan.textAttributeWarnings.length > 0) {
-    lines.push('')
-    lines.push(
-      `⚠ ${plan.textAttributeWarnings.length} pattern(s) marked -text (binary) — driver will be inactive on these until you remove -text:`
-    )
-    for (const w of plan.textAttributeWarnings) {
-      lines.push(`    ${w.pattern} (line ${w.lineIndex + 1})`)
-    }
-  }
-  if (plan.commentedOutWarnings.length > 0) {
-    lines.push('')
-    lines.push(
-      `ℹ ${plan.commentedOutWarnings.length} commented-out driver line(s) detected — install will add a live rule below each; consider removing the commented lines:`
-    )
-    for (const w of plan.commentedOutWarnings) {
-      lines.push(`    ${w.pattern} (line ${w.lineIndex + 1})`)
-    }
-  }
-  return lines.join('\n')
-}
 
 const CONFLICT_POLICIES: readonly ConflictPolicy[] = [
   'abort',
@@ -201,23 +108,6 @@ export default class Install extends SfCommand<void> {
    */
   protected promptPolicy: PolicyPrompt = defaultPolicyPrompt
 
-  /**
-   * True when the interactive policy prompt should run: `--on-conflict`
-   * unset (still 'abort' default), `--force` unset, stdout is a TTY.
-   * Non-TTY (CI) invocations without the flag keep the strict abort
-   * default so nothing surprising happens in automation.
-   */
-  private shouldPromptForPolicy(flags: {
-    'on-conflict': ConflictPolicy
-    force: boolean
-    'dry-run': boolean
-  }): boolean {
-    if (flags['dry-run']) return false
-    if (flags.force) return false
-    if (flags['on-conflict'] !== 'abort') return false
-    return Boolean(process.stdout.isTTY)
-  }
-
   @log('Install')
   public async run(): Promise<void> {
     const { flags } = await this.parse(Install)
@@ -229,7 +119,14 @@ export default class Install extends SfCommand<void> {
       ? 'overwrite'
       : flags['on-conflict']
 
-    if (this.shouldPromptForPolicy(flags)) {
+    if (
+      shouldPromptForPolicy({
+        dryRun,
+        force: flags.force,
+        onConflict: flags['on-conflict'],
+        isTTY: Boolean(process.stdout.isTTY),
+      })
+    ) {
       // Run a cheap dry-run first so we know whether to prompt at all.
       const preview = await new InstallService().installMergeDriver({
         dryRun: true,
@@ -252,17 +149,15 @@ export default class Install extends SfCommand<void> {
       })
     } catch (error) {
       if (error instanceof InstallConflictError) {
-        // `this.error` throws a CLIError internally — no need to
-        // re-throw after it. We branch here so any other error type
-        // propagates naturally via the outer catch shape oclif
-        // expects.
+        // `this.error` throws a CLIError internally — the outer catch
+        // never re-enters. Any other error type propagates naturally.
         this.error(error.message, { exit: 2 })
       }
       throw error
     }
 
     if (dryRun) {
-      this.log(formatDryRunReport(outcome))
+      this.log(formatInstallDryRunReport(outcome))
       return
     }
     // Surface diagnostic warnings to the user after a successful

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -27,6 +27,13 @@ type PolicyPrompt = (
  * conflict actions. Kept as a dependency-injectable function so tests
  * can drive the command without opening a real readline.
  */
+export const parsePromptAnswer = (raw: string): ConflictPolicy => {
+  const normalised = raw.trim().toLowerCase()
+  if (normalised === 's' || normalised === 'skip') return 'skip'
+  if (normalised === 'o' || normalised === 'overwrite') return 'overwrite'
+  return 'abort'
+}
+
 const defaultPolicyPrompt: PolicyPrompt = async conflicts => {
   const rl = createInterface({ input: process.stdin, output: process.stdout })
   try {
@@ -43,12 +50,14 @@ const defaultPolicyPrompt: PolicyPrompt = async conflicts => {
         '  [o] overwrite (replace; uninstall will restore)\n'
     )
     const answer = await new Promise<string>(resolve => {
+      // An early stdin EOF (e.g., piped empty input, detached TTY)
+      // would otherwise leave `rl.question`'s callback unresolved —
+      // 'close' fires in that case, so we resolve with '' and let
+      // parsePromptAnswer fall back to 'abort'.
+      rl.once('close', () => resolve(''))
       rl.question('Enter a / s / o [a]: ', resolve)
     })
-    const normalised = answer.trim().toLowerCase()
-    if (normalised === 's' || normalised === 'skip') return 'skip'
-    if (normalised === 'o' || normalised === 'overwrite') return 'overwrite'
-    return 'abort'
+    return parsePromptAnswer(answer)
   } finally {
     rl.close()
   }
@@ -235,34 +244,40 @@ export default class Install extends SfCommand<void> {
       }
     }
 
+    let outcome: InstallOutcome
     try {
-      const outcome = await new InstallService().installMergeDriver({
+      outcome = await new InstallService().installMergeDriver({
         dryRun,
         onConflict,
       })
-      if (dryRun) {
-        this.log(formatDryRunReport(outcome))
-        return
-      }
-      // Surface diagnostic warnings to the user after a successful
-      // install. These don't alter installation state — they're cues
-      // that the driver may not fire until the user takes action.
-      for (const w of outcome.plan.textAttributeWarnings) {
-        this.warn(
-          `${w.pattern} is marked \`-text\` (binary) on line ${w.lineIndex + 1} of .git/info/attributes. Git does not invoke merge drivers on binary files; the merge driver will be installed but inactive for this glob until you remove \`-text\`.`
-        )
-      }
-      for (const w of outcome.plan.commentedOutWarnings) {
-        this.warn(
-          `${w.pattern} has a commented-out driver rule on line ${w.lineIndex + 1} of .git/info/attributes. The live rule has been added below it — consider removing the commented line to avoid confusion.`
-        )
-      }
-      Logger.info('Merge driver installed successfully')
     } catch (error) {
       if (error instanceof InstallConflictError) {
+        // `this.error` throws a CLIError internally — no need to
+        // re-throw after it. We branch here so any other error type
+        // propagates naturally via the outer catch shape oclif
+        // expects.
         this.error(error.message, { exit: 2 })
       }
       throw error
     }
+
+    if (dryRun) {
+      this.log(formatDryRunReport(outcome))
+      return
+    }
+    // Surface diagnostic warnings to the user after a successful
+    // install. These don't alter installation state — they're cues
+    // that the driver may not fire until the user takes action.
+    for (const w of outcome.plan.textAttributeWarnings) {
+      this.warn(
+        `${w.pattern} is marked \`-text\` (binary) on line ${w.lineIndex + 1} of .git/info/attributes. Git does not invoke merge drivers on binary files; the merge driver will be installed but inactive for this glob until you remove \`-text\`.`
+      )
+    }
+    for (const w of outcome.plan.commentedOutWarnings) {
+      this.warn(
+        `${w.pattern} has a commented-out driver rule on line ${w.lineIndex + 1} of .git/info/attributes. The live rule has been added below it — consider removing the commented line to avoid confusion.`
+      )
+    }
+    Logger.info('Merge driver installed successfully')
   }
 }

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -1,8 +1,10 @@
 import { Messages } from '@salesforce/core'
 import { SfCommand } from '@salesforce/sf-plugins-core'
 import { PLUGIN_NAME } from '../../../../constant/pluginConstant.js'
-import { InstallService } from '../../../../service/InstallService.js'
-import { UninstallService } from '../../../../service/UninstallService.js'
+import {
+  InstallConflictError,
+  InstallService,
+} from '../../../../service/InstallService.js'
 import { log } from '../../../../utils/LoggingDecorator.js'
 import { Logger } from '../../../../utils/LoggingService.js'
 
@@ -22,13 +24,24 @@ export default class Install extends SfCommand<void> {
 
   @log('Install')
   public async run(): Promise<void> {
+    // `InstallService` is now idempotent by plan: re-running it reads the
+    // attributes file, compares against the desired pattern set, and only
+    // writes when something is missing. No need for the previous
+    // "uninstall first, then append" dance — that pattern destroyed user
+    // attributes on combined lines and always emitted a stray uninstall
+    // error on fresh installs.
     try {
-      await new UninstallService().uninstallMergeDriver()
-      Logger.info('Previous merge driver uninstalled successfully')
+      await new InstallService().installMergeDriver()
+      Logger.info('Merge driver installed successfully')
     } catch (error) {
-      Logger.warn('Previous merge driver uninstallation failed', error)
+      if (error instanceof InstallConflictError) {
+        // Conflicts are a user-actionable state, not a crash — surface
+        // the list and exit non-zero. Step 5 adds --on-conflict to let
+        // users pick skip/overwrite semantics instead of the default
+        // strict abort.
+        this.error(error.message, { exit: 2 })
+      }
+      throw error
     }
-    await new InstallService().installMergeDriver()
-    Logger.info('Merge driver installed successfully')
   }
 }

--- a/src/commands/git/merge/driver/install.ts
+++ b/src/commands/git/merge/driver/install.ts
@@ -129,6 +129,24 @@ const formatDryRunReport = (outcome: InstallOutcome): string => {
       lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
     }
   }
+  if (plan.textAttributeWarnings.length > 0) {
+    lines.push('')
+    lines.push(
+      `⚠ ${plan.textAttributeWarnings.length} pattern(s) marked -text (binary) — driver will be inactive on these until you remove -text:`
+    )
+    for (const w of plan.textAttributeWarnings) {
+      lines.push(`    ${w.pattern} (line ${w.lineIndex + 1})`)
+    }
+  }
+  if (plan.commentedOutWarnings.length > 0) {
+    lines.push('')
+    lines.push(
+      `ℹ ${plan.commentedOutWarnings.length} commented-out driver line(s) detected — install will add a live rule below each; consider removing the commented lines:`
+    )
+    for (const w of plan.commentedOutWarnings) {
+      lines.push(`    ${w.pattern} (line ${w.lineIndex + 1})`)
+    }
+  }
   return lines.join('\n')
 }
 
@@ -225,6 +243,19 @@ export default class Install extends SfCommand<void> {
       if (dryRun) {
         this.log(formatDryRunReport(outcome))
         return
+      }
+      // Surface diagnostic warnings to the user after a successful
+      // install. These don't alter installation state — they're cues
+      // that the driver may not fire until the user takes action.
+      for (const w of outcome.plan.textAttributeWarnings) {
+        this.warn(
+          `${w.pattern} is marked \`-text\` (binary) on line ${w.lineIndex + 1} of .git/info/attributes. Git does not invoke merge drivers on binary files; the merge driver will be installed but inactive for this glob until you remove \`-text\`.`
+        )
+      }
+      for (const w of outcome.plan.commentedOutWarnings) {
+        this.warn(
+          `${w.pattern} has a commented-out driver rule on line ${w.lineIndex + 1} of .git/info/attributes. The live rule has been added below it — consider removing the commented line to avoid confusion.`
+        )
       }
       Logger.info('Merge driver installed successfully')
     } catch (error) {

--- a/src/commands/git/merge/driver/uninstall.ts
+++ b/src/commands/git/merge/driver/uninstall.ts
@@ -1,12 +1,37 @@
 import { Messages } from '@salesforce/core'
-import { SfCommand } from '@salesforce/sf-plugins-core'
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
+import { DRIVER_NAME } from '../../../../constant/driverConstant.js'
 import { PLUGIN_NAME } from '../../../../constant/pluginConstant.js'
-import { UninstallService } from '../../../../service/UninstallService.js'
+import {
+  type UninstallOutcome,
+  UninstallService,
+} from '../../../../service/UninstallService.js'
 import { log } from '../../../../utils/LoggingDecorator.js'
 import { Logger } from '../../../../utils/LoggingService.js'
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
 const messages = Messages.loadMessages(PLUGIN_NAME, 'uninstall')
+
+const formatDryRunReport = (outcome: UninstallOutcome): string => {
+  const { plan, gitAttributesPath } = outcome
+  const dropCount = plan.actions.filter(a => a.kind === 'drop-line').length
+  const rewriteCount = plan.actions.filter(
+    a => a.kind === 'remove-merge-attr'
+  ).length
+
+  const lines: string[] = []
+  lines.push('DRY RUN — no changes applied.')
+  lines.push('')
+  lines.push('git config:')
+  lines.push(`  would remove section merge.${DRIVER_NAME}`)
+  lines.push('')
+  lines.push(`${gitAttributesPath ?? '.git/info/attributes'}:`)
+  lines.push(`  ${dropCount} line(s) would be removed (pure driver lines)`)
+  lines.push(
+    `  ${rewriteCount} line(s) would be rewritten (combined lines — user attrs preserved)`
+  )
+  return lines.join('\n')
+}
 
 export default class Uninstall extends SfCommand<void> {
   public static override readonly summary = messages.getMessage('summary')
@@ -17,11 +42,26 @@ export default class Uninstall extends SfCommand<void> {
     'git:merge:driver:disable',
   ]
 
-  public static override readonly flags = {}
+  public static override readonly flags = {
+    'dry-run': Flags.boolean({
+      summary:
+        'Plan the uninstall without touching git config or .git/info/attributes. Exits 0; shows what would be removed.',
+      default: false,
+    }),
+  }
 
   @log('Uninstall')
   public async run(): Promise<void> {
-    await new UninstallService().uninstallMergeDriver()
+    const { flags } = await this.parse(Uninstall)
+    const dryRun = flags['dry-run']
+
+    const outcome = await new UninstallService().uninstallMergeDriver({
+      dryRun,
+    })
+    if (dryRun) {
+      this.log(formatDryRunReport(outcome))
+      return
+    }
     Logger.info('Merge driver uninstalled successfully')
   }
 }

--- a/src/commands/git/merge/driver/uninstall.ts
+++ b/src/commands/git/merge/driver/uninstall.ts
@@ -1,37 +1,13 @@
 import { Messages } from '@salesforce/core'
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
-import { DRIVER_NAME } from '../../../../constant/driverConstant.js'
 import { PLUGIN_NAME } from '../../../../constant/pluginConstant.js'
-import {
-  type UninstallOutcome,
-  UninstallService,
-} from '../../../../service/UninstallService.js'
+import { formatUninstallDryRunReport } from '../../../../service/InstallReports.js'
+import { UninstallService } from '../../../../service/UninstallService.js'
 import { log } from '../../../../utils/LoggingDecorator.js'
 import { Logger } from '../../../../utils/LoggingService.js'
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
 const messages = Messages.loadMessages(PLUGIN_NAME, 'uninstall')
-
-const formatDryRunReport = (outcome: UninstallOutcome): string => {
-  const { plan, gitAttributesPath } = outcome
-  const dropCount = plan.actions.filter(a => a.kind === 'drop-line').length
-  const rewriteCount = plan.actions.filter(
-    a => a.kind === 'remove-merge-attr'
-  ).length
-
-  const lines: string[] = []
-  lines.push('DRY RUN — no changes applied.')
-  lines.push('')
-  lines.push('git config:')
-  lines.push(`  would remove section merge.${DRIVER_NAME}`)
-  lines.push('')
-  lines.push(`${gitAttributesPath ?? '.git/info/attributes'}:`)
-  lines.push(`  ${dropCount} line(s) would be removed (pure driver lines)`)
-  lines.push(
-    `  ${rewriteCount} line(s) would be rewritten (combined lines — user attrs preserved)`
-  )
-  return lines.join('\n')
-}
 
 export default class Uninstall extends SfCommand<void> {
   public static override readonly summary = messages.getMessage('summary')
@@ -59,7 +35,7 @@ export default class Uninstall extends SfCommand<void> {
       dryRun,
     })
     if (dryRun) {
-      this.log(formatDryRunReport(outcome))
+      this.log(formatUninstallDryRunReport(outcome))
       return
     }
     Logger.info('Merge driver uninstalled successfully')

--- a/src/commands/git/merge/driver/uninstall.ts
+++ b/src/commands/git/merge/driver/uninstall.ts
@@ -20,8 +20,7 @@ export default class Uninstall extends SfCommand<void> {
 
   public static override readonly flags = {
     'dry-run': Flags.boolean({
-      summary:
-        'Plan the uninstall without touching git config or .git/info/attributes. Exits 0; shows what would be removed.',
+      summary: messages.getMessage('flags.dry-run.summary'),
       default: false,
     }),
   }

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -179,7 +179,9 @@ export type InstallPlan = {
 /** Internal helper: index every rule by pattern for O(1) lookups.
  *  Returns a ReadonlyMap of readonly arrays — callers must not mutate.
  *  The map is built locally and never escapes the planner module, so
- *  this is a defensive typing rather than a runtime concern. */
+ *  the readonly typing is a defensive signature rather than a runtime
+ *  concern. Buckets are grown with `push` — cheap and bounded by the
+ *  small, typically-zero count of duplicate-pattern rules in the file. */
 const indexRulesByPattern = (
   file: ParsedFile
 ): ReadonlyMap<string, readonly { index: number; rule: RuleLine }[]> => {
@@ -187,16 +189,12 @@ const indexRulesByPattern = (
   for (let i = 0; i < file.lines.length; i++) {
     const line = file.lines[i]
     if (line.kind !== 'rule') continue
-    const existing = byPattern.get(line.pattern)
-    // Rebuild rather than mutate: aligns with the project's immutable
-    // data convention. The extra copy is bounded by duplicates of the
-    // same pattern in the file (typically 0 or 1).
-    byPattern.set(
-      line.pattern,
-      existing
-        ? [...existing, { index: i, rule: line }]
-        : [{ index: i, rule: line }]
-    )
+    const bucket = byPattern.get(line.pattern)
+    if (bucket) {
+      bucket.push({ index: i, rule: line })
+    } else {
+      byPattern.set(line.pattern, [{ index: i, rule: line }])
+    }
   }
   return byPattern
 }
@@ -216,11 +214,12 @@ const detectCommentedOutDriverLines = (
   for (let i = 0; i < file.lines.length; i++) {
     const line = file.lines[i]
     if (line.kind !== 'comment') continue
-    // Comment lines always start with `#` (optionally preceded by
-    // whitespace), followed optionally by more whitespace. `trim`
-    // collapses both ends, then we drop the `#` prefix and any
-    // whitespace following it in one pass.
-    const body = line.raw.trim().replace(/^#\s*/, '')
+    // The parser guarantees a comment's trimmed form starts with `#`
+    // (see `parseLine` in gitAttributesFile.ts). Drop that prefix;
+    // any whitespace between `#` and the pattern is absorbed by the
+    // final `trim()` on the extracted pattern below, so this function
+    // does not call `.trimStart()` on the intermediate body.
+    const body = line.raw.trim().slice(1)
     if (!body.endsWith(expectedSuffix)) continue
     const pattern = body.slice(0, -expectedSuffix.length).trim()
     if (!desiredPatterns.has(pattern)) continue

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -6,17 +6,34 @@ import {
 } from '../utils/gitAttributesFile.js'
 
 /**
+ * Prefix that marks a comment line recording the original driver we
+ * replaced during an `--on-conflict=overwrite` install. `uninstall`
+ * parses this prefix to restore the prior driver's rule line.
+ *
+ * Shape: `# sf-git-merge-driver overwrote: <original raw line>`
+ */
+export const OVERWRITE_ANNOTATION_PREFIX = '# sf-git-merge-driver overwrote: '
+
+/**
  * An action in an uninstall plan — what to do with a single line of
  * `.git/info/attributes`. Plans are applied by `UninstallService`, and
  * the shape is also what `--dry-run` renders to the user.
  *
  * `drop-line` is safe (line is pure `<pattern> merge=salesforce-source`
  * or equivalent); `remove-merge-attr` is the A8 fix — keep the user's
- * other attributes on the line and only strip our `merge=` token.
+ * other attributes on the line and only strip our `merge=` token;
+ * `restore-overwrite` reverts an install-time overwrite by writing the
+ * original raw line back (paired with a `drop-line` for the annotation
+ * comment above it).
  */
 export type UninstallAction =
   | { readonly kind: 'drop-line'; readonly lineIndex: number }
   | { readonly kind: 'remove-merge-attr'; readonly lineIndex: number }
+  | {
+      readonly kind: 'restore-overwrite'
+      readonly lineIndex: number
+      readonly originalRaw: string
+    }
 
 export type UninstallPlan = {
   readonly actions: readonly UninstallAction[]
@@ -26,13 +43,36 @@ export type UninstallPlan = {
  * Walk every rule in the parsed file; for rules whose `merge=` attribute
  * matches our driver, emit the appropriate action. Comments, blanks, and
  * rules for other merge drivers are ignored (no action).
+ *
+ * Additionally, an annotation comment of the form
+ * `# sf-git-merge-driver overwrote: <raw>` immediately above one of our
+ * rule lines triggers `restore-overwrite` — the rule is replaced with
+ * the captured raw, and the annotation comment is dropped.
  */
 export const planUninstall = (file: ParsedFile): UninstallPlan => {
   const actions: UninstallAction[] = []
+  // Loop counter advances strictly — no need to skip over already-queued
+  // annotation-drops because we only look backwards (i - 1) to detect
+  // them, and the annotation line itself is a comment, not a rule, so
+  // it never enters the rule-handling branches.
   for (let i = 0; i < file.lines.length; i++) {
     const line = file.lines[i]
     if (line.kind !== 'rule') continue
     if (getMerge(line) !== DRIVER_NAME) continue
+
+    // Check for an overwrite annotation on the preceding line.
+    const prev = i > 0 ? file.lines[i - 1] : undefined
+    if (
+      prev &&
+      prev.kind === 'comment' &&
+      prev.raw.startsWith(OVERWRITE_ANNOTATION_PREFIX)
+    ) {
+      const originalRaw = prev.raw.slice(OVERWRITE_ANNOTATION_PREFIX.length)
+      actions.push({ kind: 'drop-line', lineIndex: i - 1 })
+      actions.push({ kind: 'restore-overwrite', lineIndex: i, originalRaw })
+      continue
+    }
+
     // Rule mentions our driver. If the only attribute is our merge, the
     // whole line can be dropped safely; otherwise the user has other
     // attributes on the same line and we must preserve them by keeping
@@ -50,9 +90,11 @@ export const planUninstall = (file: ParsedFile): UninstallPlan => {
  * Conflict policy for `planInstall`.
  *   - `abort`: conflicts appear in the plan as `conflict` actions; the
  *     service refuses to write and surfaces the list to the user.
- *   - `skip`: (deferred — step 5) no-op for the conflicting pattern.
- *   - `overwrite`: (deferred — step 5) rewrite the user's line with our
- *     driver and an annotation comment for uninstall-time restore.
+ *   - `skip`: planner emits `skip-conflict` — the service leaves the
+ *     user's line untouched and does NOT add our driver for that glob.
+ *   - `overwrite`: planner emits `overwrite` — the service replaces the
+ *     user's line with our driver and inserts an annotation comment so
+ *     uninstall can restore.
  */
 export type ConflictPolicy = 'abort' | 'skip' | 'overwrite'
 
@@ -74,6 +116,21 @@ export type InstallAction =
       readonly pattern: string
       readonly existingDriver: string
       readonly lineIndex: number
+    }
+  | {
+      readonly kind: 'skip-conflict'
+      readonly pattern: string
+      readonly existingDriver: string
+      readonly lineIndex: number
+    }
+  | {
+      readonly kind: 'overwrite'
+      readonly pattern: string
+      readonly existingDriver: string
+      readonly lineIndex: number
+      /** Full raw text of the user's original rule line — used to
+       *  build the annotation comment so uninstall can restore. */
+      readonly originalRaw: string
     }
 
 export type InstallPlan = {
@@ -101,18 +158,40 @@ const indexRulesByPattern = (
   return byPattern
 }
 
+const actionForConflict = (
+  pattern: string,
+  lineIndex: number,
+  rule: RuleLine,
+  existingDriver: string,
+  policy: ConflictPolicy
+): InstallAction => {
+  if (policy === 'skip') {
+    return { kind: 'skip-conflict', pattern, existingDriver, lineIndex }
+  }
+  if (policy === 'overwrite') {
+    return {
+      kind: 'overwrite',
+      pattern,
+      existingDriver,
+      lineIndex,
+      originalRaw: rule.raw,
+    }
+  }
+  return { kind: 'conflict', pattern, existingDriver, lineIndex }
+}
+
 /**
  * Decide, for each desired pattern, whether we already own it (skip),
- * someone else owns it (conflict), or it's absent (add). Deduplicate
- * any redundant copies of our own rule as a silent healing pass.
+ * someone else owns it (conflict / skip-conflict / overwrite), or it's
+ * absent (add). Deduplicate redundant copies of our own rule silently.
  *
- * Step 5 will add a `policy: ConflictPolicy` argument and change the
- * shape of the plan when policy is 'skip' or 'overwrite'. For now the
- * planner always returns conflict actions as-is and the service throws.
+ * Policy changes only the conflict branch — patterns without competing
+ * drivers behave the same regardless of policy.
  */
 export const planInstall = (
   file: ParsedFile,
-  desiredPatterns: readonly string[]
+  desiredPatterns: readonly string[],
+  policy: ConflictPolicy = 'abort'
 ): InstallPlan => {
   const byPattern = indexRulesByPattern(file)
   const actions: InstallAction[] = []
@@ -136,12 +215,15 @@ export const planInstall = (
     })
     if (otherFirst) {
       const existingDriver = getMerge(otherFirst.rule) as string
-      actions.push({
-        kind: 'conflict',
-        pattern,
-        existingDriver,
-        lineIndex: otherFirst.index,
-      })
+      actions.push(
+        actionForConflict(
+          pattern,
+          otherFirst.index,
+          otherFirst.rule,
+          existingDriver,
+          policy
+        )
+      )
       continue
     }
     actions.push({ kind: 'add', pattern })

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -20,8 +20,8 @@ export const OVERWRITE_ANNOTATION_PREFIX = '# sf-git-merge-driver overwrote: '
  * the shape is also what `--dry-run` renders to the user.
  *
  * `drop-line` is safe (line is pure `<pattern> merge=salesforce-source`
- * or equivalent); `remove-merge-attr` is the A8 fix — keep the user's
- * other attributes on the line and only strip our `merge=` token;
+ * or equivalent); `remove-merge-attr` keeps the user's other
+ * attributes on the line and only strips our `merge=` token;
  * `restore-overwrite` reverts an install-time overwrite by writing the
  * original raw line back (paired with a `drop-line` for the annotation
  * comment above it).

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -1,0 +1,43 @@
+import { DRIVER_NAME } from '../constant/driverConstant.js'
+import { getMerge, type ParsedFile } from '../utils/gitAttributesFile.js'
+
+/**
+ * An action in an uninstall plan — what to do with a single line of
+ * `.git/info/attributes`. Plans are applied by `UninstallService`, and
+ * the shape is also what `--dry-run` renders to the user.
+ *
+ * `drop-line` is safe (line is pure `<pattern> merge=salesforce-source`
+ * or equivalent); `remove-merge-attr` is the A8 fix — keep the user's
+ * other attributes on the line and only strip our `merge=` token.
+ */
+export type UninstallAction =
+  | { readonly kind: 'drop-line'; readonly lineIndex: number }
+  | { readonly kind: 'remove-merge-attr'; readonly lineIndex: number }
+
+export type UninstallPlan = {
+  readonly actions: readonly UninstallAction[]
+}
+
+/**
+ * Walk every rule in the parsed file; for rules whose `merge=` attribute
+ * matches our driver, emit the appropriate action. Comments, blanks, and
+ * rules for other merge drivers are ignored (no action).
+ */
+export const planUninstall = (file: ParsedFile): UninstallPlan => {
+  const actions: UninstallAction[] = []
+  for (let i = 0; i < file.lines.length; i++) {
+    const line = file.lines[i]
+    if (line.kind !== 'rule') continue
+    if (getMerge(line) !== DRIVER_NAME) continue
+    // Rule mentions our driver. If the only attribute is our merge, the
+    // whole line can be dropped safely; otherwise the user has other
+    // attributes on the same line and we must preserve them by keeping
+    // the line and removing only the merge token.
+    if (line.attrs.size === 1) {
+      actions.push({ kind: 'drop-line', lineIndex: i })
+    } else {
+      actions.push({ kind: 'remove-merge-attr', lineIndex: i })
+    }
+  }
+  return { actions }
+}

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -61,10 +61,12 @@ export const planUninstall = (file: ParsedFile): UninstallPlan => {
     if (getMerge(line) !== DRIVER_NAME) continue
 
     // Check for an overwrite annotation on the preceding line.
-    const prev = i > 0 ? file.lines[i - 1] : undefined
+    // `file.lines[-1]` is undefined in JS, so no explicit bounds
+    // check needed — the `prev?.kind === 'comment'` gate below
+    // handles both "missing" and "wrong kind" with one expression.
+    const prev = file.lines[i - 1]
     if (
-      prev &&
-      prev.kind === 'comment' &&
+      prev?.kind === 'comment' &&
       prev.raw.startsWith(OVERWRITE_ANNOTATION_PREFIX)
     ) {
       const originalRaw = prev.raw.slice(OVERWRITE_ANNOTATION_PREFIX.length)
@@ -196,8 +198,11 @@ const detectCommentedOutDriverLines = (
   for (let i = 0; i < file.lines.length; i++) {
     const line = file.lines[i]
     if (line.kind !== 'comment') continue
-    // Strip the leading `#` and any whitespace that follows
-    const body = line.raw.replace(/^\s*#\s*/, '').trimEnd()
+    // Comment lines always start with `#` (optionally preceded by
+    // whitespace), followed optionally by more whitespace. `trim`
+    // collapses both ends, then we drop the `#` prefix and any
+    // whitespace following it in one pass.
+    const body = line.raw.trim().replace(/^#\s*/, '')
     if (!body.endsWith(expectedSuffix)) continue
     const pattern = body.slice(0, -expectedSuffix.length).trim()
     if (!desiredPatterns.has(pattern)) continue
@@ -268,10 +273,12 @@ export const planInstall = (
       }
       continue
     }
-    const otherFirst = matches.find(m => {
-      const merge = getMerge(m.rule)
-      return typeof merge === 'string' && merge !== DRIVER_NAME
-    })
+    // `oursFirst` is guaranteed falsy at this point (continue above
+    // otherwise), so any rule with a string merge= on this pattern
+    // is by definition a different driver. The `!== DRIVER_NAME`
+    // check is therefore structurally redundant — we keep only the
+    // `typeof merge === 'string'` guard.
+    const otherFirst = matches.find(m => typeof getMerge(m.rule) === 'string')
     if (otherFirst) {
       const existingDriver = getMerge(otherFirst.rule) as string
       actions.push(

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -1,5 +1,9 @@
 import { DRIVER_NAME } from '../constant/driverConstant.js'
-import { getMerge, type ParsedFile } from '../utils/gitAttributesFile.js'
+import {
+  getMerge,
+  type ParsedFile,
+  type RuleLine,
+} from '../utils/gitAttributesFile.js'
 
 /**
  * An action in an uninstall plan — what to do with a single line of
@@ -40,4 +44,108 @@ export const planUninstall = (file: ParsedFile): UninstallPlan => {
     }
   }
   return { actions }
+}
+
+/**
+ * Conflict policy for `planInstall`.
+ *   - `abort`: conflicts appear in the plan as `conflict` actions; the
+ *     service refuses to write and surfaces the list to the user.
+ *   - `skip`: (deferred — step 5) no-op for the conflicting pattern.
+ *   - `overwrite`: (deferred — step 5) rewrite the user's line with our
+ *     driver and an annotation comment for uninstall-time restore.
+ */
+export type ConflictPolicy = 'abort' | 'skip' | 'overwrite'
+
+/**
+ * An action in an install plan. Unlike uninstall, install actions do
+ * not all carry a `lineIndex` — new rules that don't exist in the file
+ * yet have no source line, and `add` is the planner's way of saying
+ * "append this pattern at the end".
+ */
+export type InstallAction =
+  | { readonly kind: 'add'; readonly pattern: string }
+  | {
+      readonly kind: 'skip'
+      readonly pattern: string
+      readonly lineIndex: number
+    }
+  | {
+      readonly kind: 'conflict'
+      readonly pattern: string
+      readonly existingDriver: string
+      readonly lineIndex: number
+    }
+
+export type InstallPlan = {
+  readonly actions: readonly InstallAction[]
+  /**
+   * Line indices that are exact duplicates of an already-counted
+   * `skip`. Dropped silently during apply — healing for files left
+   * with duplicates by the pre-plan install path (or manual edits).
+   */
+  readonly dedupDrops: readonly number[]
+}
+
+/** Internal helper: index every rule by pattern for O(1) lookups. */
+const indexRulesByPattern = (
+  file: ParsedFile
+): Map<string, { index: number; rule: RuleLine }[]> => {
+  const byPattern = new Map<string, { index: number; rule: RuleLine }[]>()
+  for (let i = 0; i < file.lines.length; i++) {
+    const line = file.lines[i]
+    if (line.kind !== 'rule') continue
+    const existing = byPattern.get(line.pattern)
+    if (existing) existing.push({ index: i, rule: line })
+    else byPattern.set(line.pattern, [{ index: i, rule: line }])
+  }
+  return byPattern
+}
+
+/**
+ * Decide, for each desired pattern, whether we already own it (skip),
+ * someone else owns it (conflict), or it's absent (add). Deduplicate
+ * any redundant copies of our own rule as a silent healing pass.
+ *
+ * Step 5 will add a `policy: ConflictPolicy` argument and change the
+ * shape of the plan when policy is 'skip' or 'overwrite'. For now the
+ * planner always returns conflict actions as-is and the service throws.
+ */
+export const planInstall = (
+  file: ParsedFile,
+  desiredPatterns: readonly string[]
+): InstallPlan => {
+  const byPattern = indexRulesByPattern(file)
+  const actions: InstallAction[] = []
+  const dedupDrops: number[] = []
+
+  for (const pattern of desiredPatterns) {
+    const matches = byPattern.get(pattern) ?? []
+    const oursFirst = matches.find(m => getMerge(m.rule) === DRIVER_NAME)
+    if (oursFirst) {
+      actions.push({ kind: 'skip', pattern, lineIndex: oursFirst.index })
+      for (const extra of matches) {
+        if (extra.index === oursFirst.index) continue
+        if (getMerge(extra.rule) !== DRIVER_NAME) continue
+        dedupDrops.push(extra.index)
+      }
+      continue
+    }
+    const otherFirst = matches.find(m => {
+      const merge = getMerge(m.rule)
+      return typeof merge === 'string' && merge !== DRIVER_NAME
+    })
+    if (otherFirst) {
+      const existingDriver = getMerge(otherFirst.rule) as string
+      actions.push({
+        kind: 'conflict',
+        pattern,
+        existingDriver,
+        lineIndex: otherFirst.index,
+      })
+      continue
+    }
+    actions.push({ kind: 'add', pattern })
+  }
+
+  return { actions, dedupDrops }
 }

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -64,15 +64,23 @@ export const planUninstall = (file: ParsedFile): UninstallPlan => {
     // `file.lines[-1]` is undefined in JS, so no explicit bounds
     // check needed — the `prev?.kind === 'comment'` gate below
     // handles both "missing" and "wrong kind" with one expression.
+    //
+    // Empty annotation bodies (`# sf-git-merge-driver overwrote: `
+    // with nothing after) are ignored — writing an empty rule back
+    // would corrupt the file. The annotation is treated as an
+    // ordinary comment in that case, and the driver rule falls
+    // through to the standard drop-line / remove-merge-attr path.
     const prev = file.lines[i - 1]
     if (
       prev?.kind === 'comment' &&
       prev.raw.startsWith(OVERWRITE_ANNOTATION_PREFIX)
     ) {
       const originalRaw = prev.raw.slice(OVERWRITE_ANNOTATION_PREFIX.length)
-      actions.push({ kind: 'drop-line', lineIndex: i - 1 })
-      actions.push({ kind: 'restore-overwrite', lineIndex: i, originalRaw })
-      continue
+      if (originalRaw.trim().length > 0) {
+        actions.push({ kind: 'drop-line', lineIndex: i - 1 })
+        actions.push({ kind: 'restore-overwrite', lineIndex: i, originalRaw })
+        continue
+      }
     }
 
     // Rule mentions our driver. If the only attribute is our merge, the
@@ -168,17 +176,27 @@ export type InstallPlan = {
   readonly commentedOutWarnings: readonly PatternDiagnostic[]
 }
 
-/** Internal helper: index every rule by pattern for O(1) lookups. */
+/** Internal helper: index every rule by pattern for O(1) lookups.
+ *  Returns a ReadonlyMap of readonly arrays — callers must not mutate.
+ *  The map is built locally and never escapes the planner module, so
+ *  this is a defensive typing rather than a runtime concern. */
 const indexRulesByPattern = (
   file: ParsedFile
-): Map<string, { index: number; rule: RuleLine }[]> => {
+): ReadonlyMap<string, readonly { index: number; rule: RuleLine }[]> => {
   const byPattern = new Map<string, { index: number; rule: RuleLine }[]>()
   for (let i = 0; i < file.lines.length; i++) {
     const line = file.lines[i]
     if (line.kind !== 'rule') continue
     const existing = byPattern.get(line.pattern)
-    if (existing) existing.push({ index: i, rule: line })
-    else byPattern.set(line.pattern, [{ index: i, rule: line }])
+    // Rebuild rather than mutate: aligns with the project's immutable
+    // data convention. The extra copy is bounded by duplicates of the
+    // same pattern in the file (typically 0 or 1).
+    byPattern.set(
+      line.pattern,
+      existing
+        ? [...existing, { index: i, rule: line }]
+        : [{ index: i, rule: line }]
+    )
   }
   return byPattern
 }

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -133,6 +133,13 @@ export type InstallAction =
       readonly originalRaw: string
     }
 
+/** A diagnostic a planner surfaces on the install path so the command
+ *  layer can log a warning without altering the attributes file. */
+export type PatternDiagnostic = {
+  readonly pattern: string
+  readonly lineIndex: number
+}
+
 export type InstallPlan = {
   readonly actions: readonly InstallAction[]
   /**
@@ -141,6 +148,22 @@ export type InstallPlan = {
    * with duplicates by the pre-plan install path (or manual edits).
    */
   readonly dedupDrops: readonly number[]
+  /**
+   * Patterns where a `-text` (text=false) attribute is set on the
+   * same glob, which makes git treat matching files as binary and
+   * completely bypass any merge driver. Install still proceeds, but
+   * our driver will be silently inactive on these patterns until the
+   * user removes `-text`. No auto-fix — user decides.
+   */
+  readonly textAttributeWarnings: readonly PatternDiagnostic[]
+  /**
+   * Patterns with a commented-out driver line
+   * (`# *.profile-meta.xml merge=salesforce-source`). The user
+   * explicitly disabled the driver at some point; install still adds
+   * a live rule (so the driver works) but the command layer is told
+   * so it can surface a warning.
+   */
+  readonly commentedOutWarnings: readonly PatternDiagnostic[]
 }
 
 /** Internal helper: index every rule by pattern for O(1) lookups. */
@@ -156,6 +179,31 @@ const indexRulesByPattern = (
     else byPattern.set(line.pattern, [{ index: i, rule: line }])
   }
   return byPattern
+}
+
+/**
+ * Detect commented-out driver lines of the form:
+ *   `# *.profile-meta.xml merge=salesforce-source`
+ * with optional leading whitespace. Matches for any of our desired
+ * patterns only.
+ */
+const detectCommentedOutDriverLines = (
+  file: ParsedFile,
+  desiredPatterns: ReadonlySet<string>
+): PatternDiagnostic[] => {
+  const diagnostics: PatternDiagnostic[] = []
+  const expectedSuffix = ` merge=${DRIVER_NAME}`
+  for (let i = 0; i < file.lines.length; i++) {
+    const line = file.lines[i]
+    if (line.kind !== 'comment') continue
+    // Strip the leading `#` and any whitespace that follows
+    const body = line.raw.replace(/^\s*#\s*/, '').trimEnd()
+    if (!body.endsWith(expectedSuffix)) continue
+    const pattern = body.slice(0, -expectedSuffix.length).trim()
+    if (!desiredPatterns.has(pattern)) continue
+    diagnostics.push({ pattern, lineIndex: i })
+  }
+  return diagnostics
 }
 
 const actionForConflict = (
@@ -194,11 +242,22 @@ export const planInstall = (
   policy: ConflictPolicy = 'abort'
 ): InstallPlan => {
   const byPattern = indexRulesByPattern(file)
+  const desiredSet = new Set(desiredPatterns)
   const actions: InstallAction[] = []
   const dedupDrops: number[] = []
+  const textAttributeWarnings: PatternDiagnostic[] = []
 
   for (const pattern of desiredPatterns) {
     const matches = byPattern.get(pattern) ?? []
+    // `-text` on any rule with this pattern (regardless of whether
+    // that rule mentions a merge driver) makes git treat matching
+    // files as binary — our driver will never fire. Emit one warning
+    // per (pattern, line) pair.
+    for (const match of matches) {
+      if (match.rule.attrs.get('text') === false) {
+        textAttributeWarnings.push({ pattern, lineIndex: match.index })
+      }
+    }
     const oursFirst = matches.find(m => getMerge(m.rule) === DRIVER_NAME)
     if (oursFirst) {
       actions.push({ kind: 'skip', pattern, lineIndex: oursFirst.index })
@@ -229,5 +288,12 @@ export const planInstall = (
     actions.push({ kind: 'add', pattern })
   }
 
-  return { actions, dedupDrops }
+  const commentedOutWarnings = detectCommentedOutDriverLines(file, desiredSet)
+
+  return {
+    actions,
+    dedupDrops,
+    textAttributeWarnings,
+    commentedOutWarnings,
+  }
 }

--- a/src/service/GitAttributesPlanner.ts
+++ b/src/service/GitAttributesPlanner.ts
@@ -293,18 +293,27 @@ export const planInstall = (
     }
     // `oursFirst` is guaranteed falsy at this point (continue above
     // otherwise), so any rule with a string merge= on this pattern
-    // is by definition a different driver. The `!== DRIVER_NAME`
-    // check is therefore structurally redundant — we keep only the
-    // `typeof merge === 'string'` guard.
-    const otherFirst = matches.find(m => typeof getMerge(m.rule) === 'string')
-    if (otherFirst) {
-      const existingDriver = getMerge(otherFirst.rule) as string
+    // is by definition a different driver. Capture the driver name
+    // via an explicit narrowing loop instead of a cast — keeps the
+    // type contract sound without relying on `.find` predicate
+    // narrowing (which TS doesn't thread through chained calls).
+    let otherMatch:
+      | { index: number; rule: RuleLine; existingDriver: string }
+      | undefined
+    for (const m of matches) {
+      const existingDriver = getMerge(m.rule)
+      if (typeof existingDriver === 'string') {
+        otherMatch = { index: m.index, rule: m.rule, existingDriver }
+        break
+      }
+    }
+    if (otherMatch) {
       actions.push(
         actionForConflict(
           pattern,
-          otherFirst.index,
-          otherFirst.rule,
-          existingDriver,
+          otherMatch.index,
+          otherMatch.rule,
+          otherMatch.existingDriver,
           policy
         )
       )

--- a/src/service/InstallReports.ts
+++ b/src/service/InstallReports.ts
@@ -1,0 +1,156 @@
+import { DRIVER_NAME } from '../constant/driverConstant.js'
+import type { ConflictPolicy } from './GitAttributesPlanner.js'
+import {
+  DRIVER_COMMAND,
+  DRIVER_NAME_CONFIG_VALUE,
+  type InstallOutcome,
+} from './InstallService.js'
+import type { UninstallOutcome } from './UninstallService.js'
+
+/**
+ * Human-readable dry-run report formatters. Factored out of the oclif
+ * command classes so they can be unit-tested directly — the command
+ * `run()` method is covered only by NUT tests, but the report text is
+ * user-facing and deserves a fast feedback loop.
+ */
+
+const SAMPLE_COUNT = 5
+
+/**
+ * Predicate: should the install command prompt the user interactively
+ * for a conflict policy? Pure function — the caller injects the flag
+ * state and the TTY gate so this stays testable.
+ */
+export const shouldPromptForPolicy = (input: {
+  readonly dryRun: boolean
+  readonly force: boolean
+  readonly onConflict: ConflictPolicy
+  readonly isTTY: boolean
+}): boolean => {
+  if (input.dryRun) return false
+  if (input.force) return false
+  if (input.onConflict !== 'abort') return false
+  return input.isTTY
+}
+
+export const formatInstallDryRunReport = (outcome: InstallOutcome): string => {
+  const { plan, gitAttributesPath } = outcome
+  const adds = plan.actions.filter(a => a.kind === 'add')
+  const skips = plan.actions.filter(a => a.kind === 'skip')
+  const conflicts = plan.actions.flatMap(a =>
+    a.kind === 'conflict'
+      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+      : []
+  )
+  const skippedConflicts = plan.actions.flatMap(a =>
+    a.kind === 'skip-conflict'
+      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+      : []
+  )
+  const overwrites = plan.actions.flatMap(a =>
+    a.kind === 'overwrite'
+      ? [{ pattern: a.pattern, existingDriver: a.existingDriver }]
+      : []
+  )
+  const dedupCount = plan.dedupDrops.length
+
+  const lines: string[] = []
+  lines.push('DRY RUN — no changes applied.')
+  lines.push('')
+  lines.push('git config:')
+  lines.push(
+    `  would set merge.${DRIVER_NAME}.name = "${DRIVER_NAME_CONFIG_VALUE}"`
+  )
+  lines.push(`  would set merge.${DRIVER_NAME}.driver = ${DRIVER_COMMAND}`)
+  lines.push('')
+  lines.push(`${gitAttributesPath}:`)
+  lines.push(`  ${adds.length} rule(s) would be added`)
+  if (adds.length > 0) {
+    const preview = adds
+      .slice(0, SAMPLE_COUNT)
+      .map(a => a.pattern)
+      .join(', ')
+    const more =
+      adds.length > SAMPLE_COUNT ? `, … ${adds.length - SAMPLE_COUNT} more` : ''
+    lines.push(`    ${preview}${more}`)
+  }
+  lines.push(`  ${skips.length} rule(s) already present (skipped)`)
+  lines.push(`  ${dedupCount} legacy duplicate line(s) would be removed`)
+  if (skippedConflicts.length > 0) {
+    lines.push('')
+    lines.push(
+      `${skippedConflicts.length} conflict(s) left to their current driver (--on-conflict=skip):`
+    )
+    for (const c of skippedConflicts) {
+      lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
+    }
+  }
+  if (overwrites.length > 0) {
+    lines.push('')
+    lines.push(
+      `${overwrites.length} conflict(s) would be overwritten (--on-conflict=overwrite); uninstall will restore them:`
+    )
+    for (const c of overwrites) {
+      lines.push(`    ${c.pattern} (was merge=${c.existingDriver})`)
+    }
+  }
+  if (conflicts.length > 0) {
+    lines.push('')
+    lines.push(
+      `⚠ ${conflicts.length} conflict(s) — installation would abort. Re-run with --on-conflict=skip or --on-conflict=overwrite (or --force) to proceed:`
+    )
+    for (const c of conflicts) {
+      lines.push(`    ${c.pattern} → merge=${c.existingDriver}`)
+    }
+  }
+  if (plan.textAttributeWarnings.length > 0) {
+    lines.push('')
+    lines.push(
+      `⚠ ${plan.textAttributeWarnings.length} pattern(s) marked -text (binary) — driver will be inactive on these until you remove -text:`
+    )
+    for (const w of plan.textAttributeWarnings) {
+      lines.push(`    ${w.pattern} (line ${w.lineIndex + 1})`)
+    }
+  }
+  if (plan.commentedOutWarnings.length > 0) {
+    lines.push('')
+    lines.push(
+      `ℹ ${plan.commentedOutWarnings.length} commented-out driver line(s) detected — install will add a live rule below each; consider removing the commented lines:`
+    )
+    for (const w of plan.commentedOutWarnings) {
+      lines.push(`    ${w.pattern} (line ${w.lineIndex + 1})`)
+    }
+  }
+  return lines.join('\n')
+}
+
+export const formatUninstallDryRunReport = (
+  outcome: UninstallOutcome
+): string => {
+  const { plan, gitAttributesPath } = outcome
+  const dropCount = plan.actions.filter(a => a.kind === 'drop-line').length
+  const rewriteCount = plan.actions.filter(
+    a => a.kind === 'remove-merge-attr'
+  ).length
+  const restoreCount = plan.actions.filter(
+    a => a.kind === 'restore-overwrite'
+  ).length
+
+  const lines: string[] = []
+  lines.push('DRY RUN — no changes applied.')
+  lines.push('')
+  lines.push('git config:')
+  lines.push(`  would remove section merge.${DRIVER_NAME}`)
+  lines.push('')
+  lines.push(`${gitAttributesPath ?? '.git/info/attributes'}:`)
+  lines.push(`  ${dropCount} line(s) would be removed (pure driver lines)`)
+  lines.push(
+    `  ${rewriteCount} line(s) would be rewritten (combined lines — user attrs preserved)`
+  )
+  if (restoreCount > 0) {
+    lines.push(
+      `  ${restoreCount} line(s) would be restored from overwrite annotations`
+    )
+  }
+  return lines.join('\n')
+}

--- a/src/service/InstallService.ts
+++ b/src/service/InstallService.ts
@@ -12,7 +12,6 @@ import {
   type Line,
   type ParsedFile,
   parse,
-  type RuleLine,
   ruleWithAttr,
   serialise,
 } from '../utils/gitAttributesFile.js'
@@ -33,14 +32,34 @@ const BINARY_PATH_RAW = join(
   ...BINARY_RELATIVE
 )
 
-// Ensure POSIX separators (Windows join() uses backslash) and escape both
-// single and double quotes so the path embeds safely inside the
-// `sh -c '…"…"…'` double-quoted context.
-const BINARY_PATH = BINARY_PATH_RAW.replace(/\\/g, '/')
-  .replace(/\$/g, '\\$')
-  .replace(/`/g, '\\`')
-  .replace(/"/g, '\\"')
-  .replace(/'/g, "'\\''")
+/**
+ * Escape a filesystem path for embedding inside the `sh -c '…"…"…'`
+ * driver command we store in `git config`. Exported for direct
+ * mutation-testing with crafted inputs; the module-level `BINARY_PATH`
+ * constant is its only production caller.
+ *
+ * Escapes (in fixed order, because each stage's output must not
+ * re-trigger the next stage):
+ *  1. POSIX-normalise: `\` → `/` (Windows join() yields backslashes)
+ *  2. Double every `%`: git expands `%O %A %B %P %L %S %X %Y` placeholders
+ *     inside the stored driver command before passing it to the shell,
+ *     so a literal `%A` in the path would corrupt the substitution.
+ *  3. Escape `$` and backtick: sh -c's inner "…${BINARY_PATH}…" context
+ *     would otherwise evaluate them as variable/command expansion.
+ *  4. Escape `"`: closes the inner double-quote context.
+ *  5. Escape `'`: closes the outer sh -c '…' single-quote context (the
+ *     POSIX idiom `'\''` is used).
+ */
+export const escapeBinaryPath = (raw: string): string =>
+  raw
+    .replace(/\\/g, '/')
+    .replace(/%/g, '%%')
+    .replace(/\$/g, '\\$')
+    .replace(/`/g, '\\`')
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "'\\''")
+
+const BINARY_PATH = escapeBinaryPath(BINARY_PATH_RAW)
 
 // git's merge-driver placeholder convention: %O ancestor, %A local, %B other,
 // %P output, %L conflict-marker-size, %S ancestor-label, %X local-label,
@@ -138,7 +157,7 @@ const readAttributesOrEmpty = async (path: string): Promise<string> => {
  *     already own the pattern, or we deliberately defer to the existing
  *     driver.
  */
-const applyInstallPlan = (
+export const applyInstallPlan = (
   parsed: ParsedFile,
   plan: InstallPlan
 ): ParsedFile => {
@@ -160,18 +179,21 @@ const applyInstallPlan = (
       rewrittenLines.push(existing)
       continue
     }
-    // Insert annotation comment above the rewritten rule. The planner
-    // only emits `overwrite` for rule lines (see planInstall), so the
-    // cast here is a contract narrowing rather than an assumption.
+    // The planner only emits `overwrite` for rule lines (see
+    // planInstall's conflict branch), but enforce it at runtime so
+    // a future planner change surfaces as a loud error instead of
+    // a silent .attrs-is-undefined crash inside ruleWithAttr.
+    if (existing.kind !== 'rule') {
+      throw new Error(
+        `planInstall emitted 'overwrite' for non-rule line at index ${i}: ${existing.kind}`
+      )
+    }
+    // Insert annotation comment above the rewritten rule.
     const annotation: Line = {
       kind: 'comment',
       raw: `${OVERWRITE_ANNOTATION_PREFIX}${overwrite.originalRaw}`,
     }
-    const withOurDriver: Line = ruleWithAttr(
-      existing as RuleLine,
-      'merge',
-      DRIVER_NAME
-    )
+    const withOurDriver: Line = ruleWithAttr(existing, 'merge', DRIVER_NAME)
     rewrittenLines.push(annotation, withOurDriver)
   }
 

--- a/src/service/InstallService.ts
+++ b/src/service/InstallService.ts
@@ -1,4 +1,4 @@
-import { appendFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { simpleGit } from 'simple-git'
@@ -7,8 +7,15 @@ import {
   MANIFEST_PATTERNS,
   METADATA_TYPES_PATTERNS,
 } from '../constant/metadataConstant.js'
+import {
+  addRule,
+  type ParsedFile,
+  parse,
+  serialise,
+} from '../utils/gitAttributesFile.js'
 import { getGitAttributesPath } from '../utils/gitUtils.js'
 import { log } from '../utils/LoggingDecorator.js'
+import { type InstallPlan, planInstall } from './GitAttributesPlanner.js'
 
 // Resolved from this compiled module's location:
 //   <plugin-root>/lib/service/InstallService.js → ../../bin/merge-driver.cjs
@@ -18,9 +25,14 @@ const BINARY_PATH_RAW = join(
   ...BINARY_RELATIVE
 )
 
-// Ensure POSIX separators (Windows join() uses backslash) and escape single
-// quotes so the path embeds safely inside the sh -c '...' wrapper.
-const BINARY_PATH = BINARY_PATH_RAW.replace(/\\/g, '/').replace(/'/g, "'\\''")
+// Ensure POSIX separators (Windows join() uses backslash) and escape both
+// single and double quotes so the path embeds safely inside the
+// `sh -c '…"…"…'` double-quoted context.
+const BINARY_PATH = BINARY_PATH_RAW.replace(/\\/g, '/')
+  .replace(/\$/g, '\\$')
+  .replace(/`/g, '\\`')
+  .replace(/"/g, '\\"')
+  .replace(/'/g, "'\\''")
 
 // git's merge-driver placeholder convention: %O ancestor, %A local, %B other,
 // %P output, %L conflict-marker-size, %S ancestor-label, %X local-label,
@@ -30,9 +42,58 @@ const DRIVER_COMMAND =
   `sh -c 'node "${BINARY_PATH}" -O "$1" -A "$2" -B "$3" -P "$4" -L "$5" -S "$6" -X "$7" -Y "$8"'` +
   ' -- %O %A %B %P %L %S %X %Y'
 
+const DESIRED_PATTERNS: readonly string[] = [
+  ...METADATA_TYPES_PATTERNS.map(p => `*.${p}-meta.xml`),
+  ...MANIFEST_PATTERNS,
+]
+
+/** Error thrown when the plan contains conflicts and policy is 'abort'. */
+export class InstallConflictError extends Error {
+  public readonly conflicts: readonly {
+    readonly pattern: string
+    readonly existingDriver: string
+  }[]
+
+  constructor(
+    conflicts: readonly {
+      pattern: string
+      existingDriver: string
+    }[]
+  ) {
+    const lines = conflicts.map(
+      c => `  ${c.pattern} is already owned by merge=${c.existingDriver}`
+    )
+    super(
+      `Installation aborted: ${conflicts.length} pattern(s) already configured ` +
+        `with a different merge driver.\n${lines.join('\n')}`
+    )
+    this.name = 'InstallConflictError'
+    this.conflicts = conflicts
+  }
+}
+
+/**
+ * Read `.git/info/attributes` best-effort: a missing file is equivalent
+ * to an empty one. Any other I/O error propagates.
+ */
+const readAttributesOrEmpty = async (path: string): Promise<string> => {
+  try {
+    return await readFile(path, { encoding: 'utf8' })
+  } catch (err) {
+    if (
+      err &&
+      typeof err === 'object' &&
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return ''
+    }
+    throw err
+  }
+}
+
 export class InstallService {
   @log('InstallService')
-  public async installMergeDriver(): Promise<void> {
+  public async installMergeDriver(): Promise<InstallPlan> {
     const git = simpleGit({ unsafe: { allowUnsafeMergeDriver: true } })
     await git.addConfig(
       `merge.${DRIVER_NAME}.name`,
@@ -40,20 +101,36 @@ export class InstallService {
     )
     await git.addConfig(`merge.${DRIVER_NAME}.driver`, DRIVER_COMMAND)
 
-    // Configure merge driver for each metadata type pattern
-    const metadataPatterns = METADATA_TYPES_PATTERNS.map(
-      pattern => `*.${pattern}-meta.xml merge=${DRIVER_NAME}`
-    ).join('\n')
-
-    // Configure merge driver for manifest files (package.xml, destructiveChanges.xml, etc.)
-    const manifestPatterns = MANIFEST_PATTERNS.map(
-      pattern => `${pattern} merge=${DRIVER_NAME}`
-    ).join('\n')
-
-    const content = `${metadataPatterns}\n${manifestPatterns}\n`
-
     const gitAttributesPath = await getGitAttributesPath()
+    const raw = await readAttributesOrEmpty(gitAttributesPath)
+    const parsed = parse(raw)
+    const plan = planInstall(parsed, DESIRED_PATTERNS)
 
-    await appendFile(gitAttributesPath, content, { flag: 'a' })
+    const conflicts = plan.actions.flatMap(action =>
+      action.kind === 'conflict'
+        ? [{ pattern: action.pattern, existingDriver: action.existingDriver }]
+        : []
+    )
+    if (conflicts.length > 0) throw new InstallConflictError(conflicts)
+
+    // Apply the plan: drop duplicates, then append new rules.
+    const dedup = new Set(plan.dedupDrops)
+    const kept = parsed.lines.flatMap((line, index) =>
+      dedup.has(index) ? [] : [line]
+    )
+    let next: ParsedFile = { ...parsed, lines: kept }
+    for (const action of plan.actions) {
+      if (action.kind !== 'add') continue
+      next = addRule(next, action.pattern, [['merge', DRIVER_NAME]])
+    }
+
+    // Skip the write if the file is already in the desired state —
+    // saves an I/O and keeps timestamps stable for tooling.
+    const after = serialise(next)
+    if (after !== raw) {
+      await writeFile(gitAttributesPath, after)
+    }
+
+    return plan
   }
 }

--- a/src/service/InstallService.ts
+++ b/src/service/InstallService.ts
@@ -9,13 +9,21 @@ import {
 } from '../constant/metadataConstant.js'
 import {
   addRule,
+  type Line,
   type ParsedFile,
   parse,
+  type RuleLine,
+  ruleWithAttr,
   serialise,
 } from '../utils/gitAttributesFile.js'
 import { getGitAttributesPath } from '../utils/gitUtils.js'
 import { log } from '../utils/LoggingDecorator.js'
-import { type InstallPlan, planInstall } from './GitAttributesPlanner.js'
+import {
+  type ConflictPolicy,
+  type InstallPlan,
+  OVERWRITE_ANNOTATION_PREFIX,
+  planInstall,
+} from './GitAttributesPlanner.js'
 
 // Resolved from this compiled module's location:
 //   <plugin-root>/lib/service/InstallService.js → ../../bin/merge-driver.cjs
@@ -82,6 +90,14 @@ export type InstallOptions = {
    * formatting them for the user; no `InstallConflictError` is thrown.
    */
   readonly dryRun?: boolean
+  /**
+   * How to handle patterns already owned by another merge driver.
+   * Default 'abort' (throw InstallConflictError); 'skip' leaves the
+   * user's line alone and does not add ours; 'overwrite' replaces the
+   * user's line with ours and inserts an annotation comment so the
+   * subsequent uninstall can restore the prior driver.
+   */
+  readonly onConflict?: ConflictPolicy
 }
 
 export type InstallOutcome = {
@@ -111,15 +127,55 @@ const readAttributesOrEmpty = async (path: string): Promise<string> => {
   }
 }
 
+/**
+ * Apply an install plan to the parsed file:
+ *   - Drop dedup lines.
+ *   - For each `overwrite` action, replace the existing rule line with
+ *     our driver AND insert an annotation comment above it carrying the
+ *     original raw, so uninstall can restore.
+ *   - For each `add` action, append a new rule at the end.
+ *   - `skip` and `skip-conflict` are no-ops for the file — either we
+ *     already own the pattern, or we deliberately defer to the existing
+ *     driver.
+ */
 const applyInstallPlan = (
   parsed: ParsedFile,
   plan: InstallPlan
 ): ParsedFile => {
   const dedup = new Set(plan.dedupDrops)
-  const kept = parsed.lines.flatMap((line, index) =>
-    dedup.has(index) ? [] : [line]
-  )
-  let next: ParsedFile = { ...parsed, lines: kept }
+  const overwrites = new Map<
+    number,
+    Extract<(typeof plan.actions)[number], { kind: 'overwrite' }>
+  >()
+  for (const action of plan.actions) {
+    if (action.kind === 'overwrite') overwrites.set(action.lineIndex, action)
+  }
+
+  const rewrittenLines: Line[] = []
+  for (let i = 0; i < parsed.lines.length; i++) {
+    if (dedup.has(i)) continue
+    const existing = parsed.lines[i]
+    const overwrite = overwrites.get(i)
+    if (!overwrite) {
+      rewrittenLines.push(existing)
+      continue
+    }
+    // Insert annotation comment above the rewritten rule. The planner
+    // only emits `overwrite` for rule lines (see planInstall), so the
+    // cast here is a contract narrowing rather than an assumption.
+    const annotation: Line = {
+      kind: 'comment',
+      raw: `${OVERWRITE_ANNOTATION_PREFIX}${overwrite.originalRaw}`,
+    }
+    const withOurDriver: Line = ruleWithAttr(
+      existing as RuleLine,
+      'merge',
+      DRIVER_NAME
+    )
+    rewrittenLines.push(annotation, withOurDriver)
+  }
+
+  let next: ParsedFile = { ...parsed, lines: rewrittenLines }
   for (const action of plan.actions) {
     if (action.kind !== 'add') continue
     next = addRule(next, action.pattern, [['merge', DRIVER_NAME]])
@@ -133,6 +189,7 @@ export class InstallService {
     options: InstallOptions = {}
   ): Promise<InstallOutcome> {
     const dryRun = options.dryRun ?? false
+    const policy: ConflictPolicy = options.onConflict ?? 'abort'
 
     // Plan first — reading the file and diffing against the desired
     // pattern set is side-effect free, so we can do it up front and
@@ -140,14 +197,16 @@ export class InstallService {
     const gitAttributesPath = await getGitAttributesPath()
     const raw = await readAttributesOrEmpty(gitAttributesPath)
     const parsed = parse(raw)
-    const plan = planInstall(parsed, DESIRED_PATTERNS)
+    const plan = planInstall(parsed, DESIRED_PATTERNS, policy)
 
     if (dryRun) {
       return { plan, dryRun: true, wroteAttributes: false, gitAttributesPath }
     }
 
-    // Surface conflicts before any write so an `abort` policy leaves
-    // git config and the attributes file untouched.
+    // `conflict` actions only appear when policy === 'abort'; for
+    // 'skip' they become `skip-conflict`, for 'overwrite' they become
+    // `overwrite`. Surfacing them before any write keeps the abort
+    // policy strictly non-destructive.
     const conflicts = plan.actions.flatMap(action =>
       action.kind === 'conflict'
         ? [{ pattern: action.pattern, existingDriver: action.existingDriver }]

--- a/src/service/InstallService.ts
+++ b/src/service/InstallService.ts
@@ -38,9 +38,11 @@ const BINARY_PATH = BINARY_PATH_RAW.replace(/\\/g, '/')
 // %P output, %L conflict-marker-size, %S ancestor-label, %X local-label,
 // %Y other-label. All 8 are passed — this wires %S (new) through to the
 // binary's -S flag; previous install omitted %S, forcing the static default.
-const DRIVER_COMMAND =
+export const DRIVER_COMMAND =
   `sh -c 'node "${BINARY_PATH}" -O "$1" -A "$2" -B "$3" -P "$4" -L "$5" -S "$6" -X "$7" -Y "$8"'` +
   ' -- %O %A %B %P %L %S %X %Y'
+
+export const DRIVER_NAME_CONFIG_VALUE = 'Salesforce source merge driver'
 
 const DESIRED_PATTERNS: readonly string[] = [
   ...METADATA_TYPES_PATTERNS.map(p => `*.${p}-meta.xml`),
@@ -72,6 +74,24 @@ export class InstallConflictError extends Error {
   }
 }
 
+export type InstallOptions = {
+  /**
+   * When true, plan the install and return the plan without touching
+   * `.git/config` or `.git/info/attributes`. The returned plan may
+   * contain `conflict` actions — the command layer is responsible for
+   * formatting them for the user; no `InstallConflictError` is thrown.
+   */
+  readonly dryRun?: boolean
+}
+
+export type InstallOutcome = {
+  readonly plan: InstallPlan
+  readonly dryRun: boolean
+  /** True when writeFile was called on the attributes file. */
+  readonly wroteAttributes: boolean
+  readonly gitAttributesPath: string
+}
+
 /**
  * Read `.git/info/attributes` best-effort: a missing file is equivalent
  * to an empty one. Any other I/O error propagates.
@@ -91,21 +111,43 @@ const readAttributesOrEmpty = async (path: string): Promise<string> => {
   }
 }
 
+const applyInstallPlan = (
+  parsed: ParsedFile,
+  plan: InstallPlan
+): ParsedFile => {
+  const dedup = new Set(plan.dedupDrops)
+  const kept = parsed.lines.flatMap((line, index) =>
+    dedup.has(index) ? [] : [line]
+  )
+  let next: ParsedFile = { ...parsed, lines: kept }
+  for (const action of plan.actions) {
+    if (action.kind !== 'add') continue
+    next = addRule(next, action.pattern, [['merge', DRIVER_NAME]])
+  }
+  return next
+}
+
 export class InstallService {
   @log('InstallService')
-  public async installMergeDriver(): Promise<InstallPlan> {
-    const git = simpleGit({ unsafe: { allowUnsafeMergeDriver: true } })
-    await git.addConfig(
-      `merge.${DRIVER_NAME}.name`,
-      'Salesforce source merge driver'
-    )
-    await git.addConfig(`merge.${DRIVER_NAME}.driver`, DRIVER_COMMAND)
+  public async installMergeDriver(
+    options: InstallOptions = {}
+  ): Promise<InstallOutcome> {
+    const dryRun = options.dryRun ?? false
 
+    // Plan first — reading the file and diffing against the desired
+    // pattern set is side-effect free, so we can do it up front and
+    // bail early for dry-run before touching git config.
     const gitAttributesPath = await getGitAttributesPath()
     const raw = await readAttributesOrEmpty(gitAttributesPath)
     const parsed = parse(raw)
     const plan = planInstall(parsed, DESIRED_PATTERNS)
 
+    if (dryRun) {
+      return { plan, dryRun: true, wroteAttributes: false, gitAttributesPath }
+    }
+
+    // Surface conflicts before any write so an `abort` policy leaves
+    // git config and the attributes file untouched.
     const conflicts = plan.actions.flatMap(action =>
       action.kind === 'conflict'
         ? [{ pattern: action.pattern, existingDriver: action.existingDriver }]
@@ -113,24 +155,21 @@ export class InstallService {
     )
     if (conflicts.length > 0) throw new InstallConflictError(conflicts)
 
-    // Apply the plan: drop duplicates, then append new rules.
-    const dedup = new Set(plan.dedupDrops)
-    const kept = parsed.lines.flatMap((line, index) =>
-      dedup.has(index) ? [] : [line]
-    )
-    let next: ParsedFile = { ...parsed, lines: kept }
-    for (const action of plan.actions) {
-      if (action.kind !== 'add') continue
-      next = addRule(next, action.pattern, [['merge', DRIVER_NAME]])
-    }
+    // git config goes first so the merge driver is defined before any
+    // attribute rule references it.
+    const git = simpleGit({ unsafe: { allowUnsafeMergeDriver: true } })
+    await git.addConfig(`merge.${DRIVER_NAME}.name`, DRIVER_NAME_CONFIG_VALUE)
+    await git.addConfig(`merge.${DRIVER_NAME}.driver`, DRIVER_COMMAND)
 
-    // Skip the write if the file is already in the desired state —
-    // saves an I/O and keeps timestamps stable for tooling.
+    // Apply plan and write attributes file only if the result differs
+    // from what was read — saves an I/O and keeps timestamps stable.
+    const next = applyInstallPlan(parsed, plan)
     const after = serialise(next)
-    if (after !== raw) {
+    const wroteAttributes = after !== raw
+    if (wroteAttributes) {
       await writeFile(gitAttributesPath, after)
     }
 
-    return plan
+    return { plan, dryRun: false, wroteAttributes, gitAttributesPath }
   }
 }

--- a/src/service/UninstallService.ts
+++ b/src/service/UninstallService.ts
@@ -24,7 +24,7 @@ import { planUninstall, type UninstallPlan } from './GitAttributesPlanner.js'
  *     overwrite. The paired `drop-line` for the annotation comment
  *     above is emitted by the planner and handled here uniformly.
  */
-const applyUninstallPlan = (
+export const applyUninstallPlan = (
   lines: readonly Line[],
   plan: UninstallPlan
 ): Line[] => {
@@ -40,11 +40,13 @@ const applyUninstallPlan = (
     if (drop.has(index)) return []
     const restoreRaw = restore.get(index)
     if (restoreRaw !== undefined) {
-      // `originalRaw` was captured from a serialised rule by the
-      // planner, so parse always yields exactly one line — no need for
-      // a defensive fallback. Cast with `!` documents that narrowing
-      // without adding an untested else branch to coverage.
-      return [parse(restoreRaw).lines[0] as Line]
+      // The planner rejects empty annotation bodies (see
+      // GitAttributesPlanner.planUninstall), so `restoreRaw` always
+      // has non-whitespace content here and parse yields ≥1 line.
+      // If the contract ever breaks, fall back to keeping the
+      // original line instead of writing undefined into the output.
+      const restored = parse(restoreRaw).lines[0]
+      return restored ? [restored] : [line]
     }
     if (!rewrite.has(index) || line.kind !== 'rule') return [line]
     return [ruleWithoutAttr(line, 'merge')]

--- a/src/service/UninstallService.ts
+++ b/src/service/UninstallService.ts
@@ -1,15 +1,40 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { simpleGit } from 'simple-git'
 import { DRIVER_NAME } from '../constant/driverConstant.js'
-import { GIT_EOL } from '../constant/gitConstant.js'
+import {
+  type Line,
+  parse,
+  ruleWithoutAttr,
+  serialise,
+} from '../utils/gitAttributesFile.js'
 import { getGitAttributesPath } from '../utils/gitUtils.js'
 import { log } from '../utils/LoggingDecorator.js'
 import { Logger } from '../utils/LoggingService.js'
+import { planUninstall, type UninstallPlan } from './GitAttributesPlanner.js'
 
-// This match lines like: "*.profile-meta.xml merge=sf-git-merge-driver"
-const MERGE_DRIVER_CONFIG = new RegExp(
-  String.raw`.*\s+merge\s*=\s*${DRIVER_NAME}\s*$`
-)
+/**
+ * Apply an uninstall plan to a line list:
+ *   - `drop-line` removes the line entirely.
+ *   - `remove-merge-attr` rewrites the rule line via `ruleWithoutAttr`,
+ *     stripping only the `merge=<our-driver>` token and re-serialising
+ *     the raw so the user's other attributes survive (A8 data-loss fix).
+ */
+const applyUninstallPlan = (
+  lines: readonly Line[],
+  plan: UninstallPlan
+): Line[] => {
+  const drop = new Set<number>()
+  const rewrite = new Set<number>()
+  for (const action of plan.actions) {
+    if (action.kind === 'drop-line') drop.add(action.lineIndex)
+    else rewrite.add(action.lineIndex)
+  }
+  return lines.flatMap((line, index) => {
+    if (drop.has(index)) return []
+    if (!rewrite.has(index) || line.kind !== 'rule') return [line]
+    return [ruleWithoutAttr(line, 'merge')]
+  })
+}
 
 export class UninstallService {
   @log('UninstallService')
@@ -28,13 +53,15 @@ export class UninstallService {
     try {
       const gitAttributesPath = await getGitAttributesPath()
       // Throws when the file does not exist
-      const gitAttributes = await readFile(gitAttributesPath, {
-        encoding: 'utf8',
-      })
-      const filteredAttributes = gitAttributes
-        .split(GIT_EOL)
-        .filter(line => !MERGE_DRIVER_CONFIG.test(line))
-      await writeFile(gitAttributesPath, filteredAttributes.join(GIT_EOL))
+      const raw = await readFile(gitAttributesPath, { encoding: 'utf8' })
+      const parsed = parse(raw)
+      const plan = planUninstall(parsed)
+      if (plan.actions.length === 0) return
+      const nextLines = applyUninstallPlan(parsed.lines, plan)
+      await writeFile(
+        gitAttributesPath,
+        serialise({ ...parsed, lines: nextLines })
+      )
     } catch (error) {
       Logger.error(
         'Merge driver uninstallation failed to cleanup git attributes',

--- a/src/service/UninstallService.ts
+++ b/src/service/UninstallService.ts
@@ -18,7 +18,7 @@ import { planUninstall, type UninstallPlan } from './GitAttributesPlanner.js'
  *   - `drop-line` removes the line entirely.
  *   - `remove-merge-attr` rewrites the rule line via `ruleWithoutAttr`,
  *     stripping only the `merge=<our-driver>` token and re-serialising
- *     the raw so the user's other attributes survive (A8 data-loss fix).
+ *     the raw so the user's other attributes on the same line survive.
  *   - `restore-overwrite` re-parses the captured original raw line and
  *     replaces the current line with it, undoing an install-time
  *     overwrite. The paired `drop-line` for the annotation comment

--- a/src/service/UninstallService.ts
+++ b/src/service/UninstallService.ts
@@ -3,6 +3,7 @@ import { simpleGit } from 'simple-git'
 import { DRIVER_NAME } from '../constant/driverConstant.js'
 import {
   type Line,
+  type ParsedFile,
   parse,
   ruleWithoutAttr,
   serialise,
@@ -36,37 +37,74 @@ const applyUninstallPlan = (
   })
 }
 
+export type UninstallOptions = {
+  /**
+   * When true, plan the uninstall and return the plan without touching
+   * `.git/config` or `.git/info/attributes`.
+   */
+  readonly dryRun?: boolean
+}
+
+export type UninstallOutcome = {
+  readonly plan: UninstallPlan
+  readonly dryRun: boolean
+  readonly wroteAttributes: boolean
+  readonly removedConfigSection: boolean
+  readonly gitAttributesPath: string | undefined
+}
+
 export class UninstallService {
   @log('UninstallService')
-  public async uninstallMergeDriver(): Promise<void> {
-    const git = simpleGit()
-    try {
-      // Throws when the merge driver is not installed
-      await git.raw(['config', '--remove-section', `merge.${DRIVER_NAME}`])
-    } catch (error) {
-      Logger.error(
-        'Merge driver uninstallation failed to cleanup git config',
-        error
-      )
+  public async uninstallMergeDriver(
+    options: UninstallOptions = {}
+  ): Promise<UninstallOutcome> {
+    const dryRun = options.dryRun ?? false
+
+    let removedConfigSection = false
+    if (!dryRun) {
+      const git = simpleGit()
+      try {
+        // Throws when the merge driver is not installed
+        await git.raw(['config', '--remove-section', `merge.${DRIVER_NAME}`])
+        removedConfigSection = true
+      } catch (error) {
+        Logger.error(
+          'Merge driver uninstallation failed to cleanup git config',
+          error
+        )
+      }
     }
 
+    let gitAttributesPath: string | undefined
+    let plan: UninstallPlan = { actions: [] }
+    let wroteAttributes = false
     try {
-      const gitAttributesPath = await getGitAttributesPath()
+      gitAttributesPath = await getGitAttributesPath()
       // Throws when the file does not exist
       const raw = await readFile(gitAttributesPath, { encoding: 'utf8' })
-      const parsed = parse(raw)
-      const plan = planUninstall(parsed)
-      if (plan.actions.length === 0) return
-      const nextLines = applyUninstallPlan(parsed.lines, plan)
-      await writeFile(
-        gitAttributesPath,
-        serialise({ ...parsed, lines: nextLines })
-      )
+      const parsed: ParsedFile = parse(raw)
+      plan = planUninstall(parsed)
+      if (plan.actions.length > 0 && !dryRun) {
+        const nextLines = applyUninstallPlan(parsed.lines, plan)
+        await writeFile(
+          gitAttributesPath,
+          serialise({ ...parsed, lines: nextLines })
+        )
+        wroteAttributes = true
+      }
     } catch (error) {
       Logger.error(
         'Merge driver uninstallation failed to cleanup git attributes',
         error
       )
+    }
+
+    return {
+      plan,
+      dryRun,
+      wroteAttributes,
+      removedConfigSection,
+      gitAttributesPath,
     }
   }
 }

--- a/src/service/UninstallService.ts
+++ b/src/service/UninstallService.ts
@@ -19,6 +19,10 @@ import { planUninstall, type UninstallPlan } from './GitAttributesPlanner.js'
  *   - `remove-merge-attr` rewrites the rule line via `ruleWithoutAttr`,
  *     stripping only the `merge=<our-driver>` token and re-serialising
  *     the raw so the user's other attributes survive (A8 data-loss fix).
+ *   - `restore-overwrite` re-parses the captured original raw line and
+ *     replaces the current line with it, undoing an install-time
+ *     overwrite. The paired `drop-line` for the annotation comment
+ *     above is emitted by the planner and handled here uniformly.
  */
 const applyUninstallPlan = (
   lines: readonly Line[],
@@ -26,12 +30,22 @@ const applyUninstallPlan = (
 ): Line[] => {
   const drop = new Set<number>()
   const rewrite = new Set<number>()
+  const restore = new Map<number, string>()
   for (const action of plan.actions) {
     if (action.kind === 'drop-line') drop.add(action.lineIndex)
-    else rewrite.add(action.lineIndex)
+    else if (action.kind === 'remove-merge-attr') rewrite.add(action.lineIndex)
+    else restore.set(action.lineIndex, action.originalRaw)
   }
   return lines.flatMap((line, index) => {
     if (drop.has(index)) return []
+    const restoreRaw = restore.get(index)
+    if (restoreRaw !== undefined) {
+      // `originalRaw` was captured from a serialised rule by the
+      // planner, so parse always yields exactly one line — no need for
+      // a defensive fallback. Cast with `!` documents that narrowing
+      // without adding an untested else branch to coverage.
+      return [parse(restoreRaw).lines[0] as Line]
+    }
     if (!rewrite.has(index) || line.kind !== 'rule') return [line]
     return [ruleWithoutAttr(line, 'merge')]
   })

--- a/src/service/UninstallService.ts
+++ b/src/service/UninstallService.ts
@@ -40,12 +40,15 @@ export const applyUninstallPlan = (
     if (drop.has(index)) return []
     const restoreRaw = restore.get(index)
     if (restoreRaw !== undefined) {
-      // The planner rejects empty annotation bodies (see
-      // GitAttributesPlanner.planUninstall), so `restoreRaw` always
-      // has non-whitespace content here and parse yields ≥1 line.
-      // If the contract ever breaks, fall back to keeping the
-      // original line instead of writing undefined into the output.
-      const restored = parse(restoreRaw).lines[0]
+      // The planner captures `originalRaw` from a single parsed rule
+      // line, so the round-trip string is guaranteed not to contain a
+      // newline. Parsing it yields exactly one line. If a crafted
+      // annotation body with an embedded newline ever slipped past
+      // the planner, `parse(...).lines[0]` would silently drop the
+      // rest — keep the existing line instead to avoid partial
+      // restores masquerading as successful ones.
+      const restoredLines = parse(restoreRaw).lines
+      const restored = restoredLines.length === 1 ? restoredLines[0] : undefined
       return restored ? [restored] : [line]
     }
     if (!rewrite.has(index) || line.kind !== 'rule') return [line]
@@ -94,25 +97,31 @@ export class UninstallService {
     let gitAttributesPath: string | undefined
     let plan: UninstallPlan = { actions: [] }
     let wroteAttributes = false
+    // Read-and-plan is best-effort (file may not exist, or the git-dir
+    // lookup may fail in an unusual repo). Write is NOT: a failure to
+    // persist uninstall changes must surface to the caller so the user
+    // knows the attributes file still references a driver that is now
+    // undefined in git config. Splitting the two scopes avoids the
+    // uninstall-success-but-silently-inconsistent state.
+    let serialised: string | undefined
     try {
       gitAttributesPath = await getGitAttributesPath()
-      // Throws when the file does not exist
       const raw = await readFile(gitAttributesPath, { encoding: 'utf8' })
       const parsed: ParsedFile = parse(raw)
       plan = planUninstall(parsed)
       if (plan.actions.length > 0 && !dryRun) {
         const nextLines = applyUninstallPlan(parsed.lines, plan)
-        await writeFile(
-          gitAttributesPath,
-          serialise({ ...parsed, lines: nextLines })
-        )
-        wroteAttributes = true
+        serialised = serialise({ ...parsed, lines: nextLines })
       }
     } catch (error) {
       Logger.error(
         'Merge driver uninstallation failed to cleanup git attributes',
         error
       )
+    }
+    if (serialised !== undefined && gitAttributesPath !== undefined) {
+      await writeFile(gitAttributesPath, serialised)
+      wroteAttributes = true
     }
 
     return {

--- a/src/utils/gitAttributesFile.ts
+++ b/src/utils/gitAttributesFile.ts
@@ -160,7 +160,7 @@ export const addRule = (
  * Return a new RuleLine with the given attribute removed, keeping the
  * pattern and all other attributes intact. Used by uninstall planners to
  * strip `merge=<driver>` from combined lines without losing the user's
- * other attributes (A8 regression fix).
+ * other attributes.
  */
 export const ruleWithoutAttr = (rule: RuleLine, attrName: string): RuleLine => {
   const nextAttrs = new Map(rule.attrs)

--- a/src/utils/gitAttributesFile.ts
+++ b/src/utils/gitAttributesFile.ts
@@ -156,6 +156,22 @@ export const addRule = (
   }
 }
 
+/**
+ * Return a new RuleLine with the given attribute removed, keeping the
+ * pattern and all other attributes intact. Used by uninstall planners to
+ * strip `merge=<driver>` from combined lines without losing the user's
+ * other attributes (A8 regression fix).
+ */
+export const ruleWithoutAttr = (rule: RuleLine, attrName: string): RuleLine => {
+  const nextAttrs = new Map(rule.attrs)
+  nextAttrs.delete(attrName)
+  return {
+    ...rule,
+    attrs: nextAttrs,
+    raw: serialiseRuleRaw(rule.pattern, nextAttrs),
+  }
+}
+
 const serialiseAttrToken = (name: string, value: AttrValue): string => {
   if (value === true) return name
   if (value === false) return `-${name}`

--- a/src/utils/gitAttributesFile.ts
+++ b/src/utils/gitAttributesFile.ts
@@ -172,6 +172,29 @@ export const ruleWithoutAttr = (rule: RuleLine, attrName: string): RuleLine => {
   }
 }
 
+/**
+ * Return a new RuleLine with the given attribute set to `value`. If the
+ * attribute already exists on the rule it is overwritten (and the new
+ * value is placed at the end of the serialised token order, matching
+ * `addRule`'s output). Used by the install-time overwrite policy to
+ * swap a conflicting driver to ours without losing the user's other
+ * attributes on the same line.
+ */
+export const ruleWithAttr = (
+  rule: RuleLine,
+  attrName: string,
+  value: AttrValue
+): RuleLine => {
+  const nextAttrs = new Map(rule.attrs)
+  nextAttrs.delete(attrName)
+  nextAttrs.set(attrName, value)
+  return {
+    ...rule,
+    attrs: nextAttrs,
+    raw: serialiseRuleRaw(rule.pattern, nextAttrs),
+  }
+}
+
 const serialiseAttrToken = (name: string, value: AttrValue): string => {
   if (value === true) return name
   if (value === false) return `-${name}`

--- a/src/utils/gitAttributesFile.ts
+++ b/src/utils/gitAttributesFile.ts
@@ -1,0 +1,174 @@
+import { EOL } from 'node:os'
+
+/**
+ * Structured view of `.git/info/attributes`. Parsing is lossless for the
+ * file shapes we need to handle — comments, blanks, rules, and malformed
+ * lines are preserved with their raw text so `serialise(parse(x))` is
+ * byte-for-byte equal to `x` for any well-formed input.
+ *
+ * Attribute semantics follow `git help attributes`:
+ *   `attr`       → true   (attribute set)
+ *   `-attr`      → false  (attribute unset)
+ *   `!attr`      → deleted from the map (unspecified)
+ *   `attr=value` → string value
+ *
+ * We parse enough to reason about merge-driver state; we do NOT attempt
+ * glob matching — all pattern comparisons are literal string equality
+ * against the plugin's known pattern set.
+ */
+
+export type AttrValue = string | true | false
+
+export type BlankLine = { readonly kind: 'blank'; readonly raw: string }
+export type CommentLine = { readonly kind: 'comment'; readonly raw: string }
+export type RuleLine = {
+  readonly kind: 'rule'
+  readonly pattern: string
+  readonly attrs: ReadonlyMap<string, AttrValue>
+  readonly raw: string
+}
+export type MalformedLine = { readonly kind: 'malformed'; readonly raw: string }
+
+export type Line = BlankLine | CommentLine | RuleLine | MalformedLine
+
+export type ParsedFile = {
+  readonly lines: readonly Line[]
+  readonly eol: '\n' | '\r\n'
+  readonly hasTrailingNewline: boolean
+}
+
+const COMMENT_PREFIX = '#'
+
+// Narrow cast — `node:os` types `EOL` as `string`, but at runtime it is
+// always `'\n'` (POSIX) or `'\r\n'` (Windows). Casting here keeps
+// `detectEol` branch-free and avoids a platform-dependent ternary that
+// tests on one OS can never cover.
+const OS_DEFAULT_EOL = EOL as '\n' | '\r\n'
+
+const detectEol = (text: string): '\n' | '\r\n' => {
+  if (text.includes('\r\n')) return '\r\n'
+  if (text.includes('\n')) return '\n'
+  // Fresh/empty file — match the host's native newline.
+  return OS_DEFAULT_EOL
+}
+
+const stripQuotes = (pattern: string): string => {
+  if (pattern.length >= 2 && pattern.startsWith('"') && pattern.endsWith('"')) {
+    return pattern.slice(1, -1)
+  }
+  return pattern
+}
+
+const parseAttrToken = (
+  token: string
+): { name: string; value: AttrValue } | { name: string; remove: true } => {
+  if (token.startsWith('!')) {
+    return { name: token.slice(1), remove: true }
+  }
+  if (token.startsWith('-')) {
+    return { name: token.slice(1), value: false }
+  }
+  const eq = token.indexOf('=')
+  if (eq === -1) {
+    return { name: token, value: true }
+  }
+  return { name: token.slice(0, eq), value: token.slice(eq + 1) }
+}
+
+const parseLine = (raw: string): Line => {
+  // We parse the raw line as given; caller splits on EOL first.
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) {
+    return { kind: 'blank', raw }
+  }
+  if (trimmed.startsWith(COMMENT_PREFIX)) {
+    return { kind: 'comment', raw }
+  }
+  // Tokenise on whitespace runs. Quoted patterns with spaces are rare in
+  // practice for this tool's globs, but the parser handles the common
+  // double-quote case at token boundaries.
+  const tokens = trimmed.split(/\s+/)
+  if (tokens.length < 2) {
+    // Pattern with no attributes is malformed per git's grammar.
+    return { kind: 'malformed', raw }
+  }
+  const [rawPattern, ...attrTokens] = tokens
+  const pattern = stripQuotes(rawPattern as string)
+  const attrs = new Map<string, AttrValue>()
+  for (const token of attrTokens) {
+    const parsed = parseAttrToken(token)
+    if ('remove' in parsed) {
+      attrs.delete(parsed.name)
+    } else {
+      attrs.set(parsed.name, parsed.value)
+    }
+  }
+  return { kind: 'rule', pattern, attrs, raw }
+}
+
+export const parse = (text: string): ParsedFile => {
+  if (text.length === 0) {
+    return { lines: [], eol: detectEol(text), hasTrailingNewline: true }
+  }
+  const eol = detectEol(text)
+  const hasTrailingNewline = text.endsWith(eol)
+  const body = hasTrailingNewline ? text.slice(0, -eol.length) : text
+  const rawLines = body.split(eol)
+  const lines = rawLines.map(parseLine)
+  return { lines, eol, hasTrailingNewline }
+}
+
+export const serialise = (file: ParsedFile): string => {
+  if (file.lines.length === 0) return ''
+  const body = file.lines.map(line => line.raw).join(file.eol)
+  return file.hasTrailingNewline ? body + file.eol : body
+}
+
+/**
+ * Read the merge-driver name set by a rule, or undefined if the rule has
+ * no `merge=<value>` attribute. A bare `merge` token (no `=`) is treated
+ * as invalid and returns undefined, matching git's own tolerance.
+ */
+export const getMerge = (rule: RuleLine): string | undefined => {
+  const value = rule.attrs.get('merge')
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Append a new rule to the parsed file. Preserves EOL and trailing-newline
+ * policy: if the incoming file had no trailing newline, the existing last
+ * line is terminated before the new rule is added so the result is still
+ * parseable (and ends with the detected EOL for the new rule).
+ */
+export const addRule = (
+  file: ParsedFile,
+  pattern: string,
+  attrs: readonly (readonly [string, AttrValue])[]
+): ParsedFile => {
+  const attrsMap = new Map<string, AttrValue>(attrs)
+  const raw = serialiseRuleRaw(pattern, attrsMap)
+  const ruleLine: RuleLine = { kind: 'rule', pattern, attrs: attrsMap, raw }
+  return {
+    lines: [...file.lines, ruleLine],
+    eol: file.eol,
+    // Terminating the new rule with EOL is equivalent to hasTrailingNewline=true.
+    hasTrailingNewline: true,
+  }
+}
+
+const serialiseAttrToken = (name: string, value: AttrValue): string => {
+  if (value === true) return name
+  if (value === false) return `-${name}`
+  return `${name}=${value}`
+}
+
+const serialiseRuleRaw = (
+  pattern: string,
+  attrs: ReadonlyMap<string, AttrValue>
+): string => {
+  const parts = [pattern]
+  for (const [name, value] of attrs) {
+    parts.push(serialiseAttrToken(name, value))
+  }
+  return parts.join(' ')
+}

--- a/test/integration/install.nut.ts
+++ b/test/integration/install.nut.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { execCmd } from '@salesforce/cli-plugins-testkit'
 import { expect } from 'chai'
@@ -15,6 +15,17 @@ const DRIVER_LINE_PATTERN = new RegExp(
 )
 
 const ROOT_FOLDER = './test/data'
+const ATTRS_PATH = join(ROOT_FOLDER, '.git/info/attributes')
+
+const resetRepo = (): void => {
+  execSync('shx rm -rf .git', { cwd: ROOT_FOLDER })
+  execSync('git init', { cwd: ROOT_FOLDER })
+}
+
+const seedAttributes = (content: string): void => {
+  execSync('shx mkdir -p .git/info', { cwd: ROOT_FOLDER })
+  writeFileSync(ATTRS_PATH, content, 'utf-8')
+}
 
 describe('git merge driver install', () => {
   before(() => {
@@ -24,19 +35,11 @@ describe('git merge driver install', () => {
   })
 
   after(() => {
-    // Clean up by removing .git folder and .git/info/attributes file
-    execSync('shx rm -rf .git', {
-      cwd: ROOT_FOLDER,
-    })
-    execSync('shx rm -rf node_modules', {
-      cwd: ROOT_FOLDER,
-    })
+    execSync('shx rm -rf .git', { cwd: ROOT_FOLDER })
+    execSync('shx rm -rf node_modules', { cwd: ROOT_FOLDER })
   })
 
   it('installs merge driver correctly', () => {
-    // Arrange
-    // No specific arrangement needed as we're testing a fresh install
-
     // Act
     execCmd('git merge driver install', {
       ensureExitCode: 0,
@@ -44,10 +47,9 @@ describe('git merge driver install', () => {
     })
 
     // Assert
-    const gitattributesPath = join(ROOT_FOLDER, '.git/info/attributes')
-    expect(existsSync(gitattributesPath)).to.be.true
+    expect(existsSync(ATTRS_PATH)).to.be.true
 
-    const gitattributesContent = readFileSync(gitattributesPath, 'utf-8')
+    const gitattributesContent = readFileSync(ATTRS_PATH, 'utf-8')
     expect(gitattributesContent).to.include(`.xml merge=${DRIVER_NAME}`)
 
     const gitConfigOutput = execSync('git config --list', {
@@ -73,8 +75,7 @@ describe('git merge driver install', () => {
     })
 
     // Assert — .gitattributes has each pattern exactly ONCE (no duplication)
-    const gitattributesPath = join(ROOT_FOLDER, '.git/info/attributes')
-    const gitattributesContent = readFileSync(gitattributesPath, 'utf-8')
+    const gitattributesContent = readFileSync(ATTRS_PATH, 'utf-8')
     const lines = gitattributesContent
       .split('\n')
       .filter(l => l.includes(`merge=${DRIVER_NAME}`))
@@ -84,7 +85,6 @@ describe('git merge driver install', () => {
       `Duplicate .gitattributes lines found:\n${lines.join('\n')}`
     )
 
-    // Assert — git config driver entry present (not duplicated)
     const gitConfigOutput = execSync('git config --list', {
       cwd: ROOT_FOLDER,
     }).toString()
@@ -92,5 +92,115 @@ describe('git merge driver install', () => {
       `merge.${DRIVER_NAME}.name=Salesforce source merge driver`
     )
     expect(gitConfigOutput).to.match(DRIVER_LINE_PATTERN)
+  })
+
+  describe('--dry-run', () => {
+    it('Given --dry-run on a fresh repo, When installing, Then nothing is written and git config is NOT changed', () => {
+      // Arrange — reset to a pristine repo so we can observe that
+      // no write happens.
+      resetRepo()
+
+      // Act
+      const result = execCmd('git merge driver install --dry-run', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert — no attributes file created
+      expect(existsSync(ATTRS_PATH)).to.be.false
+
+      // Assert — no merge section added to git config
+      const gitConfigOutput = execSync('git config --list', {
+        cwd: ROOT_FOLDER,
+      }).toString()
+      expect(gitConfigOutput).to.not.include(`merge.${DRIVER_NAME}.name`)
+
+      // Assert — the dry-run report mentions the pattern count
+      expect(result.shellOutput.stdout).to.include('DRY RUN')
+      expect(result.shellOutput.stdout).to.include('rule(s) would be added')
+    })
+  })
+
+  describe('--on-conflict', () => {
+    it('Given a pre-existing `merge=<other>` on our glob, When installing without a flag, Then exits 2 with a clear conflict message and leaves the file UNTOUCHED', () => {
+      // Arrange
+      resetRepo()
+      const seed = '*.profile-meta.xml merge=some-other-tool\n'
+      seedAttributes(seed)
+
+      // Act
+      const result = execCmd('git merge driver install', {
+        ensureExitCode: 2,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert — file unchanged
+      expect(readFileSync(ATTRS_PATH, 'utf-8')).to.equal(seed)
+
+      // Assert — stderr explains why
+      expect(result.shellOutput.stderr).to.include('already owned by')
+      expect(result.shellOutput.stderr).to.include('some-other-tool')
+    })
+
+    it('Given --on-conflict=skip, When installing, Then the user line is preserved and our driver is NOT added for that glob', () => {
+      // Arrange
+      resetRepo()
+      seedAttributes('*.profile-meta.xml merge=some-other-tool\n')
+
+      // Act
+      execCmd('git merge driver install --on-conflict=skip', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert — their line intact, our driver NOT added for that glob
+      const content = readFileSync(ATTRS_PATH, 'utf-8')
+      expect(content).to.include('*.profile-meta.xml merge=some-other-tool')
+      const ours = content
+        .split('\n')
+        .filter(l => l === `*.profile-meta.xml merge=${DRIVER_NAME}`)
+      expect(ours).to.have.lengthOf(0)
+    })
+
+    it('Given --on-conflict=overwrite followed by uninstall, Then the user line is restored byte-for-byte (annotation round-trip)', () => {
+      // Arrange
+      resetRepo()
+      const seed = '*.profile-meta.xml merge=some-other-tool\n'
+      seedAttributes(seed)
+
+      // Act
+      execCmd('git merge driver install --on-conflict=overwrite', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+      const afterInstall = readFileSync(ATTRS_PATH, 'utf-8')
+      expect(afterInstall).to.include('# sf-git-merge-driver overwrote:')
+      expect(afterInstall).to.include(`*.profile-meta.xml merge=${DRIVER_NAME}`)
+
+      execCmd('git merge driver uninstall', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert — their line restored byte-for-byte
+      expect(readFileSync(ATTRS_PATH, 'utf-8')).to.equal(seed)
+    })
+
+    it('Given --force, When installing against a conflict, Then it behaves like --on-conflict=overwrite', () => {
+      // Arrange
+      resetRepo()
+      seedAttributes('*.profile-meta.xml merge=some-other-tool\n')
+
+      // Act
+      execCmd('git merge driver install --force', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert
+      expect(readFileSync(ATTRS_PATH, 'utf-8')).to.include(
+        '# sf-git-merge-driver overwrote:'
+      )
+    })
   })
 })

--- a/test/integration/uninstall.nut.ts
+++ b/test/integration/uninstall.nut.ts
@@ -83,7 +83,7 @@ describe('git merge driver uninstall', () => {
     expect(gitConfigOutput).not.to.include(`merge.${DRIVER_NAME}.recursive`)
   })
 
-  describe('A8 — combined line preservation', () => {
+  describe('combined line preservation', () => {
     it('Given a line like `*.profile-meta.xml text=auto merge=salesforce-source`, When uninstalling, Then `text=auto` survives and only `merge=` is stripped', () => {
       // Arrange
       resetRepo()

--- a/test/integration/uninstall.nut.ts
+++ b/test/integration/uninstall.nut.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { execCmd } from '@salesforce/cli-plugins-testkit'
 import { expect } from 'chai'
@@ -7,6 +7,17 @@ import { after, before, describe, it } from 'mocha'
 import { DRIVER_NAME } from '../../src/constant/driverConstant.js'
 
 const ROOT_FOLDER = './test/data'
+const ATTRS_PATH = join(ROOT_FOLDER, '.git/info/attributes')
+
+const resetRepo = (): void => {
+  execSync('shx rm -rf .git', { cwd: ROOT_FOLDER })
+  execSync('git init', { cwd: ROOT_FOLDER })
+}
+
+const seedAttributes = (content: string): void => {
+  execSync('shx mkdir -p .git/info', { cwd: ROOT_FOLDER })
+  writeFileSync(ATTRS_PATH, content, 'utf-8')
+}
 
 describe('git merge driver uninstall', () => {
   before(() => {
@@ -70,5 +81,57 @@ describe('git merge driver uninstall', () => {
     expect(gitConfigOutput).not.to.include(`merge.${DRIVER_NAME}.name`)
     expect(gitConfigOutput).not.to.include(`merge.${DRIVER_NAME}.driver`)
     expect(gitConfigOutput).not.to.include(`merge.${DRIVER_NAME}.recursive`)
+  })
+
+  describe('A8 — combined line preservation', () => {
+    it('Given a line like `*.profile-meta.xml text=auto merge=salesforce-source`, When uninstalling, Then `text=auto` survives and only `merge=` is stripped', () => {
+      // Arrange
+      resetRepo()
+      seedAttributes(
+        '*.profile-meta.xml text=auto merge=salesforce-source\n* text\n'
+      )
+
+      // Act
+      execCmd('git merge driver uninstall', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert — the user's other attribute survives; only the merge
+      // attribute on our glob is removed.
+      const content = readFileSync(ATTRS_PATH, 'utf-8')
+      expect(content).to.include('*.profile-meta.xml text=auto')
+      expect(content).to.not.include(`merge=${DRIVER_NAME}`)
+      // Unrelated rule is untouched
+      expect(content).to.include('* text')
+    })
+  })
+
+  describe('--dry-run', () => {
+    it('Given --dry-run after an install, When uninstalling, Then git config and the attributes file are untouched', () => {
+      // Arrange — fresh install gives us a known state to preserve
+      resetRepo()
+      execCmd('git merge driver install', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+      const installedContent = readFileSync(ATTRS_PATH, 'utf-8')
+      const installedConfig = execSync('git config --list', {
+        cwd: ROOT_FOLDER,
+      }).toString()
+
+      // Act
+      const result = execCmd('git merge driver uninstall --dry-run', {
+        ensureExitCode: 0,
+        cwd: ROOT_FOLDER,
+      })
+
+      // Assert — file and config are byte-for-byte the post-install state
+      expect(readFileSync(ATTRS_PATH, 'utf-8')).to.equal(installedContent)
+      expect(
+        execSync('git config --list', { cwd: ROOT_FOLDER }).toString()
+      ).to.equal(installedConfig)
+      expect(result.shellOutput.stdout).to.include('DRY RUN')
+    })
   })
 })

--- a/test/unit/commands/git/merge/driver/install.test.ts
+++ b/test/unit/commands/git/merge/driver/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parsePromptAnswer } from '../../../src/commands/git/merge/driver/install.js'
+import { parsePromptAnswer } from '../../../../../../src/commands/git/merge/driver/install.js'
 
 /**
  * Direct tests for the pure helpers exported by the install command.

--- a/test/unit/commands/install.test.ts
+++ b/test/unit/commands/install.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { parsePromptAnswer } from '../../../src/commands/git/merge/driver/install.js'
+
+/**
+ * Direct tests for the pure helpers exported by the install command.
+ * The oclif `run()` method is NUT-only, but everything non-oclif is
+ * factored out so it CAN be unit-tested — starting here.
+ */
+describe('install command — parsePromptAnswer', () => {
+  describe('skip', () => {
+    it.each([
+      ['s', 'skip'],
+      ['S', 'skip'],
+      ['skip', 'skip'],
+      ['SKIP', 'skip'],
+      ['Skip', 'skip'],
+      ['  skip  ', 'skip'], // whitespace tolerance
+    ] as const)('Given answer %s, When parsing, Then returns %s', (input, expected) => {
+      expect(parsePromptAnswer(input)).toBe(expected)
+    })
+  })
+
+  describe('overwrite', () => {
+    it.each([
+      ['o', 'overwrite'],
+      ['O', 'overwrite'],
+      ['overwrite', 'overwrite'],
+      ['OVERWRITE', 'overwrite'],
+      ['Overwrite', 'overwrite'],
+      ['  overwrite  ', 'overwrite'],
+    ] as const)('Given answer %s, When parsing, Then returns %s', (input, expected) => {
+      expect(parsePromptAnswer(input)).toBe(expected)
+    })
+  })
+
+  describe('abort (default)', () => {
+    it.each([
+      'a',
+      'abort',
+      '', // empty (user hit return)
+      '   ', // whitespace only
+      'yes',
+      'maybe',
+      'o\tsomething', // tab-prefixed or extra content
+      'sx', // starts-with variants should NOT match
+      'os',
+    ])('Given ambiguous or unrecognised answer %s, When parsing, Then defaults to abort', input => {
+      expect(parsePromptAnswer(input)).toBe('abort')
+    })
+  })
+})

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  type InstallPlan,
+  planInstall,
   planUninstall,
   type UninstallPlan,
 } from '../../../src/service/GitAttributesPlanner.js'
 import {
+  addRule,
   parse,
   ruleWithoutAttr,
   serialise,
@@ -169,6 +172,250 @@ describe('GitAttributesPlanner.planUninstall', () => {
       expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 1 }])
       expect(applied).toBe('* text=auto\r\n')
       expect(applied).not.toContain('\n\n') // no mixed EOL artefacts
+    })
+  })
+})
+
+/**
+ * planInstall decides, for each pattern we want to own, whether to add a
+ * new line, silently dedup existing ones, or flag a conflict with
+ * another tool. The planner is pure domain — no I/O, no policy
+ * enforcement; the service reads the plan and chooses how to apply.
+ */
+const applyInstallPlan = (
+  input: string,
+  patterns: readonly string[],
+  plan: InstallPlan
+): string => {
+  const parsed = parse(input)
+  const dedup = new Set(plan.dedupDrops)
+  const kept = parsed.lines.flatMap((line, index) =>
+    dedup.has(index) ? [] : [line]
+  )
+  let next = { ...parsed, lines: kept }
+  for (const action of plan.actions) {
+    if (action.kind !== 'add') continue
+    // Derived via the shared helper so the test matches the service
+    next = addRule(next, action.pattern, [['merge', 'salesforce-source']])
+  }
+  // `patterns` is accepted for symmetry with the service API but not
+  // used here — the plan already contains resolved actions.
+  void patterns
+  return serialise(next)
+}
+
+describe('GitAttributesPlanner.planInstall', () => {
+  describe('A1/A2 — empty or missing file', () => {
+    it('Given an empty file, When planning install, Then every pattern gets an `add` action', () => {
+      // Arrange
+      const pf = parse('')
+      const patterns = ['*.profile-meta.xml', '*.permissionset-meta.xml']
+
+      // Act
+      const plan = planInstall(pf, patterns)
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'add', pattern: '*.profile-meta.xml' },
+        { kind: 'add', pattern: '*.permissionset-meta.xml' },
+      ])
+      expect(plan.dedupDrops).toEqual([])
+    })
+  })
+
+  describe('A3 — file has rules on non-overlapping globs', () => {
+    it('Given unrelated rules, When planning install, Then only `add` actions for our patterns; user content untouched', () => {
+      // Arrange
+      const input = '* text=auto eol=lf\n*.sh text\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'add', pattern: '*.profile-meta.xml' },
+      ])
+      const applied = applyInstallPlan(input, ['*.profile-meta.xml'], plan)
+      expect(applied).toBe(
+        '* text=auto eol=lf\n*.sh text\n*.profile-meta.xml merge=salesforce-source\n'
+      )
+    })
+  })
+
+  describe('A4 — idempotent re-install', () => {
+    it('Given our rule is already present, When planning install, Then action is `skip` (no add, no conflict)', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+      expect(plan.dedupDrops).toEqual([])
+    })
+  })
+
+  describe('dedup — legacy duplicates', () => {
+    it('Given the same `pattern merge=salesforce-source` line appears twice, When planning install, Then the extra copy is silently dropped (skip + dedup)', () => {
+      // Arrange — the shape left behind by a previous buggy install path
+      const input =
+        '*.profile-meta.xml merge=salesforce-source\n*.profile-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert — skip the first, dedup the second; no-log-required healing
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+      expect(plan.dedupDrops).toEqual([1])
+      const applied = applyInstallPlan(input, ['*.profile-meta.xml'], plan)
+      expect(applied).toBe('*.profile-meta.xml merge=salesforce-source\n')
+    })
+
+    it('Given three duplicate copies, When planning install, Then two are dedup-dropped', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=salesforce-source\n'.repeat(3)
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert
+      expect(plan.dedupDrops).toEqual([1, 2])
+    })
+  })
+
+  describe('A6 — conflict with another merge driver', () => {
+    it('Given `merge=<other>` on our glob, When planning install, Then action is `conflict` carrying the existing driver name', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=some-other-tool\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert
+      expect(plan.actions).toEqual([
+        {
+          kind: 'conflict',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'some-other-tool',
+          lineIndex: 0,
+        },
+      ])
+    })
+  })
+
+  describe('A7 — user has non-merge attributes on our glob', () => {
+    it('Given a rule with text/eol but no merge, When planning install, Then `add` is emitted (new line; git accumulates attrs across lines)', () => {
+      // Arrange
+      const input = '*.profile-meta.xml text=auto eol=lf\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'add', pattern: '*.profile-meta.xml' },
+      ])
+      const applied = applyInstallPlan(input, ['*.profile-meta.xml'], plan)
+      expect(applied).toBe(
+        '*.profile-meta.xml text=auto eol=lf\n*.profile-meta.xml merge=salesforce-source\n'
+      )
+    })
+  })
+
+  describe('A8 — user has combined merge=ours + other attrs', () => {
+    it('Given a combined line, When planning install, Then action is `skip` (we are already the configured driver)', () => {
+      // Arrange
+      const input = '*.profile-meta.xml text=auto merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+  })
+
+  describe('mixed pattern set', () => {
+    it('Given a mix of absent / already-ours / conflicting patterns, When planning install, Then each pattern gets its correct action independently', () => {
+      // Arrange
+      const input =
+        '*.profile-meta.xml merge=salesforce-source\n' +
+        '*.permissionset-meta.xml merge=some-other-tool\n'
+      const pf = parse(input)
+      const patterns = [
+        '*.profile-meta.xml',
+        '*.permissionset-meta.xml',
+        '*.labels-meta.xml',
+      ]
+
+      // Act
+      const plan = planInstall(pf, patterns)
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
+        {
+          kind: 'conflict',
+          pattern: '*.permissionset-meta.xml',
+          existingDriver: 'some-other-tool',
+          lineIndex: 1,
+        },
+        { kind: 'add', pattern: '*.labels-meta.xml' },
+      ])
+    })
+  })
+
+  describe('non-rule lines in the file', () => {
+    it('Given the file has comments and blanks, When planning install, Then they are ignored by the pattern index (not misinterpreted as rules)', () => {
+      // Arrange — the indexRulesByPattern pass must skip comment/blank
+      // lines cleanly so their line indices never leak into actions.
+      const input = '# header\n\n*.profile-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — skip action references the rule line (index 2), not the
+      // comment or blank that precede it.
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 2 },
+      ])
+    })
+  })
+
+  describe('dedup filter — only-our-driver duplicates are counted', () => {
+    it('Given the same pattern has both our rule and another rule without merge, When planning install, Then the non-ours rule is NOT dedup-dropped', () => {
+      // Arrange — first rule is ours, second rule is on the same pattern
+      // but carries user attributes (no merge token). That second rule
+      // should survive — dedup only targets redundant copies of OUR
+      // driver, not unrelated user rules on the same pattern.
+      const input =
+        '*.profile-meta.xml merge=salesforce-source\n' +
+        '*.profile-meta.xml text=auto\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+      expect(plan.dedupDrops).toEqual([])
     })
   })
 })

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -90,7 +90,7 @@ describe('GitAttributesPlanner.planUninstall', () => {
     })
   })
 
-  describe('A8 — combined lines (user attributes + our merge)', () => {
+  describe('combined lines (user attributes + our merge)', () => {
     it('Given a combined line with our merge driver, When planning, Then action is remove-merge-attr (not drop-line) and the user attributes survive serialisation', () => {
       // Arrange
       const input =
@@ -132,7 +132,7 @@ describe('GitAttributesPlanner.planUninstall', () => {
 
   describe('comments and commented-out driver lines', () => {
     it('Given a commented-out driver line, When planning, Then no actions are emitted (comment stays)', () => {
-      // Arrange — A9 scenario from the spike
+      // Arrange — commented-out driver line on one of our globs
       const input = '# *.profile-meta.xml merge=salesforce-source\n'
       const pf = parse(input)
 
@@ -144,7 +144,7 @@ describe('GitAttributesPlanner.planUninstall', () => {
     })
   })
 
-  describe('A10 — CRLF preservation', () => {
+  describe('CRLF preservation', () => {
     it('Given a CRLF file with a pure driver line, When applying the plan, Then the remaining file keeps CRLF endings', () => {
       // Arrange
       const input =
@@ -174,7 +174,7 @@ const applyInstallPlanToString = (input: string, plan: InstallPlan): string => {
 }
 
 describe('GitAttributesPlanner.planInstall', () => {
-  describe('A1/A2 — empty or missing file', () => {
+  describe('empty or missing file', () => {
     it('Given an empty file, When planning install, Then every pattern gets an `add` action', () => {
       // Arrange
       const pf = parse('')
@@ -191,7 +191,7 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
-  describe('A3 — file has rules on non-overlapping globs', () => {
+  describe('file has rules on non-overlapping globs', () => {
     it('Given unrelated rules, When planning install, Then only `add` actions for our patterns; user content untouched', () => {
       // Arrange
       const input = '* text=auto eol=lf\n*.sh text\n'
@@ -211,7 +211,7 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
-  describe('A4 — idempotent re-install', () => {
+  describe('idempotent re-install', () => {
     it('Given our rule is already present, When planning install, Then action is `skip` (no add, no conflict)', () => {
       // Arrange
       const input = '*.profile-meta.xml merge=salesforce-source\n'
@@ -259,7 +259,7 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
-  describe('A6 — conflict with another merge driver', () => {
+  describe('conflict with another merge driver', () => {
     it('Given `merge=<other>` on our glob, When planning install, Then action is `conflict` carrying the existing driver name', () => {
       // Arrange
       const input = '*.profile-meta.xml merge=some-other-tool\n'
@@ -307,7 +307,7 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
-  describe('A7 — user has non-merge attributes on our glob', () => {
+  describe('user has non-merge attributes on our glob', () => {
     it('Given a rule with text/eol but no merge, When planning install, Then `add` is emitted (new line; git accumulates attrs across lines)', () => {
       // Arrange
       const input = '*.profile-meta.xml text=auto eol=lf\n'
@@ -327,7 +327,7 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
-  describe('A8 — user has combined merge=ours + other attrs', () => {
+  describe('user has combined merge=ours + other attrs', () => {
     it('Given a combined line, When planning install, Then action is `skip` (we are already the configured driver)', () => {
       // Arrange
       const input = '*.profile-meta.xml text=auto merge=salesforce-source\n'
@@ -491,7 +491,7 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
-  describe('A9 — commented-out driver line (user disabled us)', () => {
+  describe('commented-out driver line (user disabled us)', () => {
     it('Given a commented-out driver line for one of our patterns, When planning install, Then a warning is surfaced and the pattern is still added (live rule lives below the comment)', () => {
       // Arrange — `# *.profile-meta.xml merge=salesforce-source` shouldn't
       // prevent us from re-adding the live rule, but it's useful to

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -466,6 +466,106 @@ describe('GitAttributesPlanner.planInstall', () => {
     })
   })
 
+  describe('A9 — commented-out driver line (user disabled us)', () => {
+    it('Given a commented-out driver line for one of our patterns, When planning install, Then a warning is surfaced and the pattern is still added (live rule lives below the comment)', () => {
+      // Arrange — `# *.profile-meta.xml merge=salesforce-source` shouldn't
+      // prevent us from re-adding the live rule, but it's useful to
+      // surface because users who manually disabled us will see two
+      // lines after install and wonder why.
+      const input = '# *.profile-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — live rule is added; commented-out warning is recorded
+      // in the plan so the command can log it.
+      expect(plan.actions).toEqual([
+        { kind: 'add', pattern: '*.profile-meta.xml' },
+      ])
+      expect(plan.commentedOutWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+
+    it('Given no commented-out driver lines, When planning install, Then commentedOutWarnings is empty', () => {
+      // Arrange
+      const pf = parse('*.profile-meta.xml merge=salesforce-source\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.commentedOutWarnings).toEqual([])
+    })
+
+    it('Given a commented-out driver for a pattern OUTSIDE the desired set, When planning install, Then no warning is emitted', () => {
+      // Arrange — user kept a comment about a legacy glob we no longer
+      // target. Not our business.
+      const pf = parse('# *.old-meta.xml merge=salesforce-source\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.commentedOutWarnings).toEqual([])
+    })
+  })
+
+  describe('-text footgun — glob marked binary', () => {
+    it('Given one of our patterns has `-text` on a separate rule, When planning install, Then textAttributeWarnings is populated', () => {
+      // Arrange — with `-text`, git treats the file as binary and
+      // never invokes a merge driver, so our install would be silently
+      // inactive. Surface it so the user can fix or confirm.
+      const input = '*.profile-meta.xml -text\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.textAttributeWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+
+    it('Given one of our patterns has `-text` combined with other attrs on the same line, When planning install, Then the warning still fires', () => {
+      // Arrange
+      const pf = parse('*.profile-meta.xml -text eol=lf\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.textAttributeWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+
+    it('Given a pattern with `text=auto` (set, not unset), When planning install, Then no `-text` warning is emitted', () => {
+      // Arrange
+      const pf = parse('*.profile-meta.xml text=auto\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — `text=auto` is fine; only explicit `-text` (false) is
+      // the footgun we warn about.
+      expect(plan.textAttributeWarnings).toEqual([])
+    })
+
+    it('Given a `-text` rule on a pattern NOT in the desired set, When planning install, Then no warning is emitted', () => {
+      // Arrange — we only care about patterns we plan to own.
+      const pf = parse('*.bin -text\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.textAttributeWarnings).toEqual([])
+    })
+  })
+
   describe('conflict policy — default is abort (backward compat)', () => {
     it('Given planInstall called without a policy argument, When planning a conflict, Then the `conflict` action is emitted (unchanged from step 3)', () => {
       // Arrange

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -418,4 +418,115 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.dedupDrops).toEqual([])
     })
   })
+
+  describe('conflict policy — skip', () => {
+    it('Given a conflicting driver with policy=skip, When planning, Then action is `skip-conflict` (no `conflict`, no `add`)', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=some-other-tool\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'skip')
+
+      // Assert — planner downgrades the conflict to a skip-conflict
+      // action so the service writes nothing for this pattern. The
+      // other-tool line remains the source of truth for that glob.
+      expect(plan.actions).toEqual([
+        {
+          kind: 'skip-conflict',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'some-other-tool',
+          lineIndex: 0,
+        },
+      ])
+    })
+  })
+
+  describe('conflict policy — overwrite', () => {
+    it('Given a conflicting driver with policy=overwrite, When planning, Then action is `overwrite` carrying the original raw line', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=some-other-tool\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'overwrite')
+
+      // Assert — planner records the original line so the applier can
+      // write an annotation comment alongside the replacement. The
+      // annotation lets `uninstall` restore the prior driver.
+      expect(plan.actions).toEqual([
+        {
+          kind: 'overwrite',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'some-other-tool',
+          lineIndex: 0,
+          originalRaw: '*.profile-meta.xml merge=some-other-tool',
+        },
+      ])
+    })
+  })
+
+  describe('conflict policy — default is abort (backward compat)', () => {
+    it('Given planInstall called without a policy argument, When planning a conflict, Then the `conflict` action is emitted (unchanged from step 3)', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=some-other-tool\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.actions).toEqual([
+        {
+          kind: 'conflict',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'some-other-tool',
+          lineIndex: 0,
+        },
+      ])
+    })
+  })
+})
+
+describe('GitAttributesPlanner.planUninstall — annotation-based restore', () => {
+  it('Given an annotation comment above our driver line, When planning uninstall, Then action is `restore-overwrite` carrying the original raw and the annotation line is also dropped', () => {
+    // Arrange — the shape that `overwrite` install produces
+    const input =
+      '# sf-git-merge-driver overwrote: *.profile-meta.xml merge=some-other-tool\n' +
+      '*.profile-meta.xml merge=salesforce-source\n'
+    const pf = parse(input)
+
+    // Act
+    const plan = planUninstall(pf)
+
+    // Assert — restore the captured original, and drop the annotation
+    // comment that announced the overwrite.
+    expect(plan.actions).toEqual([
+      {
+        kind: 'drop-line',
+        lineIndex: 0,
+      },
+      {
+        kind: 'restore-overwrite',
+        lineIndex: 1,
+        originalRaw: '*.profile-meta.xml merge=some-other-tool',
+      },
+    ])
+  })
+
+  it('Given an annotation comment NOT followed by one of our driver lines, When planning, Then the annotation is preserved (we did not write it)', () => {
+    // Arrange — defensive: a user-typed comment happens to share our
+    // prefix. We do not destroy it unless it sits directly above our
+    // rule (the shape only install produces).
+    const input =
+      '# sf-git-merge-driver overwrote: just some random text\n' +
+      '* text=auto\n'
+    const pf = parse(input)
+
+    // Act
+    const plan = planUninstall(pf)
+
+    // Assert — no restore, no drop; nothing for the planner to do.
+    expect(plan.actions).toEqual([])
+  })
 })

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -311,6 +311,24 @@ describe('GitAttributesPlanner.planInstall', () => {
         },
       ])
     })
+
+    it('Given OUR driver appears first and another driver second on the same pattern, When planning, Then the action is `skip` (ours), not `conflict`', () => {
+      // Guards the "merge !== DRIVER_NAME" filter used when picking
+      // the conflict line — if that predicate were stripped, the
+      // planner would incorrectly flag this as a conflict.
+      const pf = parse(
+        '*.profile-meta.xml merge=salesforce-source\n*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'], 'abort')
+
+      // Assert — our rule wins on first match; the conflict filter
+      // correctly excludes our own driver when scanning for others.
+      expect(plan.actions).toEqual([
+        { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
   })
 
   describe('A7 — user has non-merge attributes on our glob', () => {
@@ -510,6 +528,85 @@ describe('GitAttributesPlanner.planInstall', () => {
       // Assert
       expect(plan.commentedOutWarnings).toEqual([])
     })
+
+    it('Given a commented-out driver with extra whitespace after the #, When planning, Then the pattern is still detected', () => {
+      // Regex guard — `/^\s*#\s*/` must strip the whitespace, not
+      // reject the line for having extra spaces.
+      const pf = parse('#    *.profile-meta.xml merge=salesforce-source\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.commentedOutWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+
+    it('Given a commented-out driver line with trailing whitespace, When planning, Then the pattern is still detected (trimEnd must strip tail spaces)', () => {
+      // Kills `trimEnd` → `trimStart` mutation. With `trimStart`
+      // instead, trailing spaces survive and the suffix check
+      // `endsWith(' merge=salesforce-source')` fails.
+      const pf = parse('# *.profile-meta.xml merge=salesforce-source   \n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.commentedOutWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+
+    it('Given a rule line whose raw happens to contain a # mid-line, When planning, Then it is NOT classified as a commented-out driver', () => {
+      // Kills the regex anchor mutation `/\s*#\s*/` (no `^`). Without
+      // the leading-anchor, `# merge=salesforce-source` anywhere in
+      // the raw would match. We build such a case by planting the
+      // suffix inside a fake comment whose # is NOT at the start.
+      // Parser classifies this as a comment (starts with #), so we
+      // instead use an actual rule whose pattern contains a # (rare
+      // but possible per git attributes grammar).
+      const pf = parse('*.p#fake merge=salesforce-source\n')
+
+      // Act — desired set intentionally doesn't include the weird
+      // pattern; we just need to prove the detector doesn't lift it.
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — no commented-out warning (the line is a rule, not
+      // a comment, so the detector shouldn't touch it).
+      expect(plan.commentedOutWarnings).toEqual([])
+    })
+
+    it('Given a commented-out driver with NO space after the #, When planning, Then the pattern is still detected', () => {
+      // Kills the regex mutation `/^\s*#\s/` (requires one space)
+      // and `/^\s*#\S*/` (greedy non-space eats the pattern).
+      const pf = parse('#*.profile-meta.xml merge=salesforce-source\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert
+      expect(plan.commentedOutWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
+
+    it('Given a comment that happens to end with our suffix but the pattern has trailing whitespace, When planning, Then it is still matched (trim handles trailing spaces)', () => {
+      // Kills the `body.slice(...).trim()` → `body.slice(...)` mutant.
+      // Without trim, a pattern with a trailing space wouldn't be in
+      // the desired set and the detection would silently drop it.
+      const pf = parse('#    *.profile-meta.xml    merge=salesforce-source\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — note: trailing whitespace is trimmed off BEFORE the
+      // suffix check by trimEnd(), so the slice itself yields
+      // '*.profile-meta.xml' already. The trim is belt-and-suspenders.
+      expect(plan.commentedOutWarnings).toEqual([
+        { pattern: '*.profile-meta.xml', lineIndex: 0 },
+      ])
+    })
   })
 
   describe('-text footgun — glob marked binary', () => {
@@ -628,5 +725,39 @@ describe('GitAttributesPlanner.planUninstall — annotation-based restore', () =
 
     // Assert — no restore, no drop; nothing for the planner to do.
     expect(plan.actions).toEqual([])
+  })
+
+  it('Given our driver line at the very first file position (index 0, no prior line), When planning uninstall, Then it is treated as a plain drop-line (not a restore)', () => {
+    // Kills the `i > 0 ? file.lines[i - 1] : undefined` mutants: if
+    // that guard is removed, `file.lines[-1]` is undefined — same
+    // observable result — but swapping `> 0` to `>= 0` would still
+    // treat index 0 differently.
+    const input = '*.profile-meta.xml merge=salesforce-source\n'
+    const pf = parse(input)
+
+    // Act
+    const plan = planUninstall(pf)
+
+    // Assert — plain drop-line at index 0, not a restore-overwrite.
+    expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 0 }])
+  })
+
+  it('Given a non-comment line directly above our driver rule, When planning, Then no restore-overwrite is emitted', () => {
+    // Kills the `prev.kind === 'comment' && ...` → `true && ...` mutant.
+    // Without the kind check, a rule line above ours whose raw happens
+    // to start with our annotation prefix would incorrectly trigger a
+    // restore. Here we use a rule whose raw cannot possibly match the
+    // prefix (but the mutant would skip the kind check and try to
+    // startsWith on any raw).
+    const input =
+      '*.other-meta.xml text=auto\n*.profile-meta.xml merge=salesforce-source\n'
+    const pf = parse(input)
+
+    // Act
+    const plan = planUninstall(pf)
+
+    // Assert — drop-line only, no restore; the preceding non-comment
+    // rule line does not qualify as an annotation.
+    expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 1 }])
   })
 })

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import {
+  planUninstall,
+  type UninstallPlan,
+} from '../../../src/service/GitAttributesPlanner.js'
+import {
+  parse,
+  ruleWithoutAttr,
+  serialise,
+} from '../../../src/utils/gitAttributesFile.js'
+
+/**
+ * planUninstall maps a parsed `.git/info/attributes` to a list of actions
+ * that cleanly remove the driver's presence while preserving any user
+ * attributes that happen to share the same line. Both the plan itself
+ * and the serialised result of applying it are asserted, because the
+ * plan is also what `--dry-run` will show to users.
+ */
+
+const applyPlan = (input: string, plan: UninstallPlan): string => {
+  const parsed = parse(input)
+  const actionByIndex = new Map(plan.actions.map(a => [a.lineIndex, a]))
+  const kept = parsed.lines.flatMap((line, index) => {
+    const action = actionByIndex.get(index)
+    if (!action) return [line]
+    if (action.kind === 'drop-line') return []
+    // remove-merge-attr — reuse the shared helper so the test mirrors
+    // what UninstallService actually does.
+    if (line.kind !== 'rule') return [line]
+    return [ruleWithoutAttr(line, 'merge')]
+  })
+  return serialise({ ...parsed, lines: kept })
+}
+
+describe('GitAttributesPlanner.planUninstall', () => {
+  describe('no-op cases', () => {
+    it('Given an empty file, When planning uninstall, Then no actions are emitted', () => {
+      // Arrange
+      const pf = parse('')
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert
+      expect(plan.actions).toEqual([])
+    })
+
+    it('Given a file with only unrelated rules, When planning uninstall, Then no actions are emitted', () => {
+      // Arrange
+      const pf = parse('* text=auto\n*.sh text eol=lf\n')
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert
+      expect(plan.actions).toEqual([])
+    })
+
+    it('Given a file with rules for other merge drivers, When planning uninstall, Then no actions are emitted', () => {
+      // Arrange
+      const pf = parse('*.profile-meta.xml merge=some-other-tool\n')
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert
+      expect(plan.actions).toEqual([])
+    })
+  })
+
+  describe('pure driver lines', () => {
+    it('Given a line containing ONLY our merge driver, When planning, Then action is drop-line', () => {
+      // Arrange
+      const input = '*.profile-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert
+      expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 0 }])
+      expect(applyPlan(input, plan)).toBe('')
+    })
+
+    it('Given multiple pure driver lines interleaved with user content, When planning, Then each pure line is dropped, user content preserved', () => {
+      // Arrange
+      const input =
+        '* text=auto\n*.profile-meta.xml merge=salesforce-source\n*.sh text\n*.permissionset-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'drop-line', lineIndex: 1 },
+        { kind: 'drop-line', lineIndex: 3 },
+      ])
+      expect(applyPlan(input, plan)).toBe('* text=auto\n*.sh text\n')
+    })
+  })
+
+  describe('A8 — combined lines (user attributes + our merge)', () => {
+    it('Given a combined line with our merge driver, When planning, Then action is remove-merge-attr (not drop-line) and the user attributes survive serialisation', () => {
+      // Arrange
+      const input =
+        '*.profile-meta.xml text=auto eol=lf merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert — the line stays; only the merge attribute is removed
+      expect(plan.actions).toEqual([
+        { kind: 'remove-merge-attr', lineIndex: 0 },
+      ])
+      const applied = applyPlan(input, plan)
+      expect(applied).toContain('*.profile-meta.xml')
+      expect(applied).toContain('text=auto')
+      expect(applied).toContain('eol=lf')
+      expect(applied).not.toContain('merge=salesforce-source')
+    })
+
+    it('Given a combined line where our merge is the only surviving attribute after removal, When planning, Then action is remove-merge-attr (not drop-line)', () => {
+      // Rationale: when attrs are reduced to zero, we keep the line as
+      // malformed rather than silently deleting; user-intent signal
+      // ("I cared about this pattern") is preserved. Uninstall is
+      // conservative about destroying lines.
+      // Arrange — one user attr + our merge
+      const input = '*.profile-meta.xml text merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert
+      expect(plan.actions).toEqual([
+        { kind: 'remove-merge-attr', lineIndex: 0 },
+      ])
+    })
+  })
+
+  describe('comments and commented-out driver lines', () => {
+    it('Given a commented-out driver line, When planning, Then no actions are emitted (comment stays)', () => {
+      // Arrange — A9 scenario from the spike
+      const input = '# *.profile-meta.xml merge=salesforce-source\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planUninstall(pf)
+
+      // Assert — commented line is not a rule, planner ignores it
+      expect(plan.actions).toEqual([])
+    })
+  })
+
+  describe('A10 — CRLF preservation', () => {
+    it('Given a CRLF file with a pure driver line, When applying the plan, Then the remaining file keeps CRLF endings', () => {
+      // Arrange
+      const input =
+        '* text=auto\r\n*.profile-meta.xml merge=salesforce-source\r\n'
+      const pf = parse(input)
+
+      // Act
+      const plan = planUninstall(pf)
+      const applied = applyPlan(input, plan)
+
+      // Assert
+      expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 1 }])
+      expect(applied).toBe('* text=auto\r\n')
+      expect(applied).not.toContain('\n\n') // no mixed EOL artefacts
+    })
+  })
+})

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -5,34 +5,21 @@ import {
   planUninstall,
   type UninstallPlan,
 } from '../../../src/service/GitAttributesPlanner.js'
-import {
-  addRule,
-  parse,
-  ruleWithoutAttr,
-  serialise,
-} from '../../../src/utils/gitAttributesFile.js'
+import { applyInstallPlan } from '../../../src/service/InstallService.js'
+import { applyUninstallPlan } from '../../../src/service/UninstallService.js'
+import { parse, serialise } from '../../../src/utils/gitAttributesFile.js'
 
 /**
- * planUninstall maps a parsed `.git/info/attributes` to a list of actions
- * that cleanly remove the driver's presence while preserving any user
- * attributes that happen to share the same line. Both the plan itself
- * and the serialised result of applying it are asserted, because the
- * plan is also what `--dry-run` will show to users.
+ * Apply helpers reuse the services' real `applyInstallPlan` /
+ * `applyUninstallPlan` so these tests cannot drift against production
+ * behaviour. The previous local reimplementations are gone — drift
+ * was hiding a real bug (restore-overwrite actions were silently
+ * ignored at the test level).
  */
-
 const applyPlan = (input: string, plan: UninstallPlan): string => {
   const parsed = parse(input)
-  const actionByIndex = new Map(plan.actions.map(a => [a.lineIndex, a]))
-  const kept = parsed.lines.flatMap((line, index) => {
-    const action = actionByIndex.get(index)
-    if (!action) return [line]
-    if (action.kind === 'drop-line') return []
-    // remove-merge-attr — reuse the shared helper so the test mirrors
-    // what UninstallService actually does.
-    if (line.kind !== 'rule') return [line]
-    return [ruleWithoutAttr(line, 'merge')]
-  })
-  return serialise({ ...parsed, lines: kept })
+  const nextLines = applyUninstallPlan(parsed.lines, plan)
+  return serialise({ ...parsed, lines: nextLines })
 }
 
 describe('GitAttributesPlanner.planUninstall', () => {
@@ -179,29 +166,11 @@ describe('GitAttributesPlanner.planUninstall', () => {
 /**
  * planInstall decides, for each pattern we want to own, whether to add a
  * new line, silently dedup existing ones, or flag a conflict with
- * another tool. The planner is pure domain — no I/O, no policy
- * enforcement; the service reads the plan and chooses how to apply.
+ * another tool. Apply helper reuses the real service function.
  */
-const applyInstallPlan = (
-  input: string,
-  patterns: readonly string[],
-  plan: InstallPlan
-): string => {
+const applyInstallPlanToString = (input: string, plan: InstallPlan): string => {
   const parsed = parse(input)
-  const dedup = new Set(plan.dedupDrops)
-  const kept = parsed.lines.flatMap((line, index) =>
-    dedup.has(index) ? [] : [line]
-  )
-  let next = { ...parsed, lines: kept }
-  for (const action of plan.actions) {
-    if (action.kind !== 'add') continue
-    // Derived via the shared helper so the test matches the service
-    next = addRule(next, action.pattern, [['merge', 'salesforce-source']])
-  }
-  // `patterns` is accepted for symmetry with the service API but not
-  // used here — the plan already contains resolved actions.
-  void patterns
-  return serialise(next)
+  return serialise(applyInstallPlan(parsed, plan))
 }
 
 describe('GitAttributesPlanner.planInstall', () => {
@@ -236,7 +205,7 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.actions).toEqual([
         { kind: 'add', pattern: '*.profile-meta.xml' },
       ])
-      const applied = applyInstallPlan(input, ['*.profile-meta.xml'], plan)
+      const applied = applyInstallPlanToString(input, plan)
       expect(applied).toBe(
         '* text=auto eol=lf\n*.sh text\n*.profile-meta.xml merge=salesforce-source\n'
       )
@@ -275,7 +244,7 @@ describe('GitAttributesPlanner.planInstall', () => {
         { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
       ])
       expect(plan.dedupDrops).toEqual([1])
-      const applied = applyInstallPlan(input, ['*.profile-meta.xml'], plan)
+      const applied = applyInstallPlanToString(input, plan)
       expect(applied).toBe('*.profile-meta.xml merge=salesforce-source\n')
     })
 
@@ -344,7 +313,7 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.actions).toEqual([
         { kind: 'add', pattern: '*.profile-meta.xml' },
       ])
-      const applied = applyInstallPlan(input, ['*.profile-meta.xml'], plan)
+      const applied = applyInstallPlanToString(input, plan)
       expect(applied).toBe(
         '*.profile-meta.xml text=auto eol=lf\n*.profile-meta.xml merge=salesforce-source\n'
       )
@@ -394,6 +363,38 @@ describe('GitAttributesPlanner.planInstall', () => {
         },
         { kind: 'add', pattern: '*.labels-meta.xml' },
       ])
+    })
+  })
+
+  describe('planInstall+applyInstallPlan integration — overwrite + dedup round-trip', () => {
+    it('Given policy=overwrite on a conflicting file, When the plan is applied and then planUninstall runs, Then the original user driver is restored byte-identical', () => {
+      // Arrange — the seed is what a real user would have before our
+      // first install under --on-conflict=overwrite.
+      const seed = '*.profile-meta.xml merge=user-driver\n'
+      const pf = parse(seed)
+
+      // Act — install with overwrite + apply
+      const installPlan = planInstall(pf, ['*.profile-meta.xml'], 'overwrite')
+      expect(installPlan.actions).toHaveLength(1)
+      expect(installPlan.actions[0]?.kind).toBe('overwrite')
+      const afterInstall = serialise(applyInstallPlan(pf, installPlan))
+      expect(afterInstall).toContain(
+        '# sf-git-merge-driver overwrote: *.profile-meta.xml merge=user-driver'
+      )
+      expect(afterInstall).toContain(
+        '*.profile-meta.xml merge=salesforce-source'
+      )
+
+      // Act — uninstall + apply
+      const afterInstallParsed = parse(afterInstall)
+      const uninstallPlan = planUninstall(afterInstallParsed)
+      const afterUninstall = serialise({
+        ...afterInstallParsed,
+        lines: applyUninstallPlan(afterInstallParsed.lines, uninstallPlan),
+      })
+
+      // Assert — seed restored byte-identical
+      expect(afterUninstall).toBe(seed)
     })
   })
 

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -188,7 +188,6 @@ describe('GitAttributesPlanner.planInstall', () => {
         { kind: 'add', pattern: '*.profile-meta.xml' },
         { kind: 'add', pattern: '*.permissionset-meta.xml' },
       ])
-      expect(plan.dedupDrops).toEqual([])
     })
   })
 
@@ -225,7 +224,6 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.actions).toEqual([
         { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
       ])
-      expect(plan.dedupDrops).toEqual([])
     })
   })
 
@@ -281,10 +279,15 @@ describe('GitAttributesPlanner.planInstall', () => {
       ])
     })
 
-    it('Given OUR driver appears first and another driver second on the same pattern, When planning, Then the action is `skip` (ours), not `conflict`', () => {
-      // Guards the "merge !== DRIVER_NAME" filter used when picking
-      // the conflict line — if that predicate were stripped, the
-      // planner would incorrectly flag this as a conflict.
+    it('Given OUR driver appears first and another driver second on the same pattern, When planning, Then the action is `skip` (ours), not `conflict`, AND the other-driver line is NOT dedup-dropped', () => {
+      // Guards two invariants:
+      //  - the "merge !== DRIVER_NAME" filter used when picking
+      //    the conflict line — if that predicate were stripped,
+      //    the planner would incorrectly flag this as a conflict
+      //  - the "!== DRIVER_NAME" check in the dedup loop — if that
+      //    predicate were stripped, the planner would incorrectly
+      //    schedule the OTHER driver's line for deletion, silently
+      //    destroying data the user had deliberately configured.
       const pf = parse(
         '*.profile-meta.xml merge=salesforce-source\n*.profile-meta.xml merge=some-other-tool\n'
       )
@@ -297,6 +300,10 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.actions).toEqual([
         { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
       ])
+      // Line index 1 holds `merge=some-other-tool` — it must NOT
+      // be dedup'd. This assertion kills the "!== DRIVER_NAME"
+      // conditional mutant in the dedup loop.
+      expect(plan.dedupDrops).toEqual([])
     })
   })
 
@@ -434,7 +441,6 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.actions).toEqual([
         { kind: 'skip', pattern: '*.profile-meta.xml', lineIndex: 0 },
       ])
-      expect(plan.dedupDrops).toEqual([])
     })
   })
 
@@ -607,6 +613,47 @@ describe('GitAttributesPlanner.planInstall', () => {
       expect(plan.commentedOutWarnings).toEqual([
         { pattern: '*.profile-meta.xml', lineIndex: 0 },
       ])
+    })
+
+    it('Given a rule line whose pattern starts with one extra char then matches a desired pattern and ends with our suffix, When planning, Then NO commented-out warning is emitted (detector must only consider comment lines)', () => {
+      // Kills the `line.kind !== 'comment'` → `if (false)` mutant on
+      // the detector's loop. If the kind guard were bypassed, the
+      // detector would strip the first char of a RULE's raw line
+      // (thinking it was the `#`) and the remaining body would end
+      // with ` merge=salesforce-source`. A pattern of `@*.profile-meta.xml`
+      // loses the `@` on slice(1), leaving a body whose slice(0,-24)
+      // equals one of our desired patterns — a false-positive diagnostic.
+      //
+      // The proper code short-circuits on `kind === 'rule'` before
+      // any slicing runs, so no warning is emitted.
+      const pf = parse('@*.profile-meta.xml merge=salesforce-source\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — rule line, not a comment; detector should not touch.
+      expect(plan.commentedOutWarnings).toEqual([])
+    })
+
+    it('Given a comment body that does NOT end with the driver suffix but slicing off 24 chars coincidentally yields a desired pattern, When planning, Then NO warning is emitted', () => {
+      // Kills the `body.endsWith(expectedSuffix)` → `if (false)` mutant.
+      // `expectedSuffix` is ' merge=salesforce-source' (24 chars).
+      // If the endsWith guard were removed, a body whose last 24 chars
+      // happen to differ from the suffix but whose prefix (after the
+      // 24-char slice) happens to equal one of our desired patterns
+      // would still emit a false-positive diagnostic. The trailing
+      // '!' here breaks the suffix match while preserving the 18-char
+      // prefix '*.profile-meta.xml' once the final 24 characters are
+      // sliced off.
+      const pf = parse('# *.profile-meta.xml merge=salesforce-source!\n')
+
+      // Act
+      const plan = planInstall(pf, ['*.profile-meta.xml'])
+
+      // Assert — the correct code refuses to diagnose because the
+      // suffix doesn't actually match. The mutant would falsely
+      // emit one.
+      expect(plan.commentedOutWarnings).toEqual([])
     })
   })
 

--- a/test/unit/service/GitAttributesPlanner.test.ts
+++ b/test/unit/service/GitAttributesPlanner.test.ts
@@ -727,6 +727,37 @@ describe('GitAttributesPlanner.planUninstall — annotation-based restore', () =
     expect(plan.actions).toEqual([])
   })
 
+  it('Given an annotation with an empty body above our driver, When planning uninstall, Then NO restore is emitted and the driver rule falls through to drop-line (no crash)', () => {
+    // Kills the empty-body crash: `parse("")` yields zero lines, so
+    // writing `undefined` into the attributes file would corrupt it.
+    // The planner ignores annotations whose body is empty / whitespace.
+    const input =
+      '# sf-git-merge-driver overwrote: \n' +
+      '*.profile-meta.xml merge=salesforce-source\n'
+    const pf = parse(input)
+
+    // Act
+    const plan = planUninstall(pf)
+
+    // Assert — the annotation is treated as an ordinary comment (no
+    // action), the driver rule is dropped normally. The annotation
+    // itself stays; user can remove it if they want.
+    expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 1 }])
+  })
+
+  it('Given an annotation with a whitespace-only body, When planning uninstall, Then it is also treated as empty (no restore)', () => {
+    const input =
+      '# sf-git-merge-driver overwrote:    \n' +
+      '*.profile-meta.xml merge=salesforce-source\n'
+    const pf = parse(input)
+
+    // Act
+    const plan = planUninstall(pf)
+
+    // Assert
+    expect(plan.actions).toEqual([{ kind: 'drop-line', lineIndex: 1 }])
+  })
+
   it('Given our driver line at the very first file position (index 0, no prior line), When planning uninstall, Then it is treated as a plain drop-line (not a restore)', () => {
     // Kills the `i > 0 ? file.lines[i - 1] : undefined` mutants: if
     // that guard is removed, `file.lines[-1]` is undefined — same

--- a/test/unit/service/InstallReports.test.ts
+++ b/test/unit/service/InstallReports.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  InstallPlan,
+  UninstallPlan,
+} from '../../../src/service/GitAttributesPlanner.js'
+import {
+  formatInstallDryRunReport,
+  formatUninstallDryRunReport,
+  shouldPromptForPolicy,
+} from '../../../src/service/InstallReports.js'
+import type { InstallOutcome } from '../../../src/service/InstallService.js'
+import type { UninstallOutcome } from '../../../src/service/UninstallService.js'
+
+const makeInstallPlan = (
+  overrides: Partial<InstallPlan> = {}
+): InstallPlan => ({
+  actions: [],
+  dedupDrops: [],
+  textAttributeWarnings: [],
+  commentedOutWarnings: [],
+  ...overrides,
+})
+
+const makeInstallOutcome = (plan: InstallPlan): InstallOutcome => ({
+  plan,
+  dryRun: true,
+  wroteAttributes: false,
+  gitAttributesPath: '.git/info/attributes',
+})
+
+const makeUninstallPlan = (
+  overrides: Partial<UninstallPlan> = {}
+): UninstallPlan => ({
+  actions: [],
+  ...overrides,
+})
+
+const makeUninstallOutcome = (plan: UninstallPlan): UninstallOutcome => ({
+  plan,
+  dryRun: true,
+  wroteAttributes: false,
+  removedConfigSection: false,
+  gitAttributesPath: '.git/info/attributes',
+})
+
+describe('InstallReports.shouldPromptForPolicy', () => {
+  it('Given dryRun=true, Then returns false regardless of TTY', () => {
+    expect(
+      shouldPromptForPolicy({
+        dryRun: true,
+        force: false,
+        onConflict: 'abort',
+        isTTY: true,
+      })
+    ).toBe(false)
+  })
+
+  it('Given force=true, Then returns false (force implies overwrite)', () => {
+    expect(
+      shouldPromptForPolicy({
+        dryRun: false,
+        force: true,
+        onConflict: 'abort',
+        isTTY: true,
+      })
+    ).toBe(false)
+  })
+
+  it('Given onConflict=skip (non-abort), Then returns false (user already chose)', () => {
+    expect(
+      shouldPromptForPolicy({
+        dryRun: false,
+        force: false,
+        onConflict: 'skip',
+        isTTY: true,
+      })
+    ).toBe(false)
+  })
+
+  it('Given onConflict=overwrite, Then returns false', () => {
+    expect(
+      shouldPromptForPolicy({
+        dryRun: false,
+        force: false,
+        onConflict: 'overwrite',
+        isTTY: true,
+      })
+    ).toBe(false)
+  })
+
+  it('Given onConflict=abort + isTTY=false (CI), Then returns false (no hidden prompt in CI)', () => {
+    expect(
+      shouldPromptForPolicy({
+        dryRun: false,
+        force: false,
+        onConflict: 'abort',
+        isTTY: false,
+      })
+    ).toBe(false)
+  })
+
+  it('Given onConflict=abort + isTTY=true + no force + no dryRun, Then returns true', () => {
+    expect(
+      shouldPromptForPolicy({
+        dryRun: false,
+        force: false,
+        onConflict: 'abort',
+        isTTY: true,
+      })
+    ).toBe(true)
+  })
+})
+
+describe('InstallReports.formatInstallDryRunReport', () => {
+  // Helper: the two header lines are shared across every scenario.
+  // Pinning them once lets the scenario tests focus on per-plan deltas.
+  const EXPECTED_HEADER_START =
+    'DRY RUN — no changes applied.\n\ngit config:\n  would set merge.salesforce-source.name = "Salesforce source merge driver"\n  would set merge.salesforce-source.driver = '
+  const EXPECTED_PATH_LINE = '\n\n.git/info/attributes:\n'
+
+  it('Given an empty plan, Then the entire report body is the zero-counts skeleton (no extra blocks)', () => {
+    // Arrange
+    const outcome = makeInstallOutcome(makeInstallPlan())
+
+    // Act
+    const report = formatInstallDryRunReport(outcome)
+
+    // Assert — whole-string equality against the expected skeleton,
+    // not just substring presence. Mutations that drop any literal or
+    // change any count are caught here.
+    const rest = report.slice(report.indexOf(EXPECTED_PATH_LINE))
+    expect(report.startsWith(EXPECTED_HEADER_START)).toBe(true)
+    expect(rest).toBe(
+      '\n\n.git/info/attributes:\n  0 rule(s) would be added\n  0 rule(s) already present (skipped)\n  0 legacy duplicate line(s) would be removed'
+    )
+  })
+
+  const bodyOf = (report: string): string =>
+    report.slice(report.indexOf(EXPECTED_PATH_LINE) + EXPECTED_PATH_LINE.length)
+
+  it('Given ≤5 adds, Then the preview line lists every pattern with no "more" suffix', () => {
+    const plan = makeInstallPlan({
+      actions: [
+        { kind: 'add', pattern: '*.profile-meta.xml' },
+        { kind: 'add', pattern: '*.permissionset-meta.xml' },
+      ],
+    })
+    expect(bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))).toBe(
+      '  2 rule(s) would be added\n' +
+        '    *.profile-meta.xml, *.permissionset-meta.xml\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed'
+    )
+  })
+
+  it('Given >5 adds, Then the preview shows exactly the first 5 patterns plus a "… N more" suffix with the correct count', () => {
+    const patterns = [
+      '*.a-meta.xml',
+      '*.b-meta.xml',
+      '*.c-meta.xml',
+      '*.d-meta.xml',
+      '*.e-meta.xml',
+      '*.f-meta.xml',
+      '*.g-meta.xml',
+    ]
+    const plan = makeInstallPlan({
+      actions: patterns.map(p => ({ kind: 'add', pattern: p }) as const),
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  7 rule(s) would be added\n' +
+        '    *.a-meta.xml, *.b-meta.xml, *.c-meta.xml, *.d-meta.xml, *.e-meta.xml, … 2 more\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed'
+    )
+  })
+
+  it('Given exactly 5 adds, Then NO "more" suffix appears (boundary — the > check must be strict, not >=)', () => {
+    const plan = makeInstallPlan({
+      actions: [
+        { kind: 'add', pattern: '*.a-meta.xml' },
+        { kind: 'add', pattern: '*.b-meta.xml' },
+        { kind: 'add', pattern: '*.c-meta.xml' },
+        { kind: 'add', pattern: '*.d-meta.xml' },
+        { kind: 'add', pattern: '*.e-meta.xml' },
+      ],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).not.toContain('more')
+    expect(body).toContain(
+      '    *.a-meta.xml, *.b-meta.xml, *.c-meta.xml, *.d-meta.xml, *.e-meta.xml'
+    )
+  })
+
+  it('Given `conflict` actions, Then the abort-block text is byte-exact', () => {
+    const plan = makeInstallPlan({
+      actions: [
+        {
+          kind: 'conflict',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'tool-a',
+          lineIndex: 0,
+        },
+      ],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed\n' +
+        '\n' +
+        '⚠ 1 conflict(s) — installation would abort. Re-run with --on-conflict=skip or --on-conflict=overwrite (or --force) to proceed:\n' +
+        '    *.profile-meta.xml → merge=tool-a'
+    )
+  })
+
+  it('Given `skip-conflict` actions, Then the skip-block text is byte-exact', () => {
+    const plan = makeInstallPlan({
+      actions: [
+        {
+          kind: 'skip-conflict',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'tool-b',
+          lineIndex: 0,
+        },
+      ],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed\n' +
+        '\n' +
+        '1 conflict(s) left to their current driver (--on-conflict=skip):\n' +
+        '    *.profile-meta.xml → merge=tool-b'
+    )
+  })
+
+  it('Given `overwrite` actions, Then the overwrite-block text is byte-exact and mentions uninstall restore', () => {
+    const plan = makeInstallPlan({
+      actions: [
+        {
+          kind: 'overwrite',
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'tool-c',
+          lineIndex: 0,
+          originalRaw: '*.profile-meta.xml merge=tool-c',
+        },
+      ],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed\n' +
+        '\n' +
+        '1 conflict(s) would be overwritten (--on-conflict=overwrite); uninstall will restore them:\n' +
+        '    *.profile-meta.xml (was merge=tool-c)'
+    )
+  })
+
+  it('Given textAttributeWarnings, Then the -text block text is byte-exact and line number is 1-based', () => {
+    const plan = makeInstallPlan({
+      textAttributeWarnings: [{ pattern: '*.profile-meta.xml', lineIndex: 4 }],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed\n' +
+        '\n' +
+        '⚠ 1 pattern(s) marked -text (binary) — driver will be inactive on these until you remove -text:\n' +
+        '    *.profile-meta.xml (line 5)'
+    )
+  })
+
+  it('Given commentedOutWarnings, Then the info-block text is byte-exact and line number is 1-based', () => {
+    const plan = makeInstallPlan({
+      commentedOutWarnings: [{ pattern: '*.profile-meta.xml', lineIndex: 2 }],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed\n' +
+        '\n' +
+        'ℹ 1 commented-out driver line(s) detected — install will add a live rule below each; consider removing the commented lines:\n' +
+        '    *.profile-meta.xml (line 3)'
+    )
+  })
+
+  it('Given dedupDrops, Then the count is surfaced exactly', () => {
+    const plan = makeInstallPlan({ dedupDrops: [1, 4] })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  0 rule(s) already present (skipped)\n' +
+        '  2 legacy duplicate line(s) would be removed'
+    )
+  })
+
+  it('Given `skip` actions, Then the already-present count is accurate', () => {
+    const plan = makeInstallPlan({
+      actions: [
+        { kind: 'skip', pattern: '*.a-meta.xml', lineIndex: 0 },
+        { kind: 'skip', pattern: '*.b-meta.xml', lineIndex: 1 },
+      ],
+    })
+    const body = bodyOf(formatInstallDryRunReport(makeInstallOutcome(plan)))
+    expect(body).toBe(
+      '  0 rule(s) would be added\n' +
+        '  2 rule(s) already present (skipped)\n' +
+        '  0 legacy duplicate line(s) would be removed'
+    )
+  })
+})
+
+describe('InstallReports.formatUninstallDryRunReport', () => {
+  it('Given an empty plan, Then the entire report body is the zero-counts skeleton with NO restore line', () => {
+    // Arrange
+    const outcome = makeUninstallOutcome(makeUninstallPlan())
+
+    // Act
+    const report = formatUninstallDryRunReport(outcome)
+
+    // Assert — whole-string equality pins every literal. Any mutation
+    // (dropping a line, changing a count word, flipping a plural) is
+    // caught here. Uses the git-config section that names the driver.
+    expect(report).toBe(
+      'DRY RUN — no changes applied.\n' +
+        '\n' +
+        'git config:\n' +
+        '  would remove section merge.salesforce-source\n' +
+        '\n' +
+        '.git/info/attributes:\n' +
+        '  0 line(s) would be removed (pure driver lines)\n' +
+        '  0 line(s) would be rewritten (combined lines — user attrs preserved)'
+    )
+  })
+
+  it('Given drop-line + remove-merge-attr actions, Then the body reports exact counts byte-for-byte', () => {
+    const plan = makeUninstallPlan({
+      actions: [
+        { kind: 'drop-line', lineIndex: 0 },
+        { kind: 'drop-line', lineIndex: 1 },
+        { kind: 'remove-merge-attr', lineIndex: 2 },
+      ],
+    })
+    const report = formatUninstallDryRunReport(makeUninstallOutcome(plan))
+    expect(report).toBe(
+      'DRY RUN — no changes applied.\n' +
+        '\n' +
+        'git config:\n' +
+        '  would remove section merge.salesforce-source\n' +
+        '\n' +
+        '.git/info/attributes:\n' +
+        '  2 line(s) would be removed (pure driver lines)\n' +
+        '  1 line(s) would be rewritten (combined lines — user attrs preserved)'
+    )
+  })
+
+  it('Given restore-overwrite actions, Then the dedicated restore block is appended byte-exact', () => {
+    const plan = makeUninstallPlan({
+      actions: [
+        { kind: 'drop-line', lineIndex: 0 }, // the annotation comment
+        {
+          kind: 'restore-overwrite',
+          lineIndex: 1,
+          originalRaw: '*.profile-meta.xml merge=some-other',
+        },
+      ],
+    })
+    const report = formatUninstallDryRunReport(makeUninstallOutcome(plan))
+    expect(report).toBe(
+      'DRY RUN — no changes applied.\n' +
+        '\n' +
+        'git config:\n' +
+        '  would remove section merge.salesforce-source\n' +
+        '\n' +
+        '.git/info/attributes:\n' +
+        '  1 line(s) would be removed (pure driver lines)\n' +
+        '  0 line(s) would be rewritten (combined lines — user attrs preserved)\n' +
+        '  1 line(s) would be restored from overwrite annotations'
+    )
+  })
+
+  it('Given gitAttributesPath is undefined, Then the path line uses the ".git/info/attributes" default literal exactly', () => {
+    const plan = makeUninstallPlan()
+    const outcome: UninstallOutcome = {
+      ...makeUninstallOutcome(plan),
+      gitAttributesPath: undefined,
+    }
+    const report = formatUninstallDryRunReport(outcome)
+    // Whole-string equality proves the `?? '.git/info/attributes'`
+    // fallback fires — mutation of either side of the ?? is caught.
+    expect(report).toBe(
+      'DRY RUN — no changes applied.\n' +
+        '\n' +
+        'git config:\n' +
+        '  would remove section merge.salesforce-source\n' +
+        '\n' +
+        '.git/info/attributes:\n' +
+        '  0 line(s) would be removed (pure driver lines)\n' +
+        '  0 line(s) would be rewritten (combined lines — user attrs preserved)'
+    )
+  })
+
+  it('Given gitAttributesPath is a custom absolute path, Then the path line uses that literal (proves the ?? left-hand wins)', () => {
+    const plan = makeUninstallPlan()
+    const outcome: UninstallOutcome = {
+      ...makeUninstallOutcome(plan),
+      gitAttributesPath: '/custom/path/attributes',
+    }
+    const report = formatUninstallDryRunReport(outcome)
+    expect(report).toContain('/custom/path/attributes:')
+    expect(report).not.toContain('.git/info/attributes:')
+  })
+})

--- a/test/unit/service/InstallService.test.ts
+++ b/test/unit/service/InstallService.test.ts
@@ -162,7 +162,7 @@ describe('InstallService', () => {
     })
   })
 
-  describe('A1/A2 — fresh install (attributes file missing or empty)', () => {
+  describe('fresh install (attributes file missing or empty)', () => {
     it('Given the attributes file does not exist, When installing, Then writeFile creates it with every desired pattern', async () => {
       // Arrange — readFile already rejects with ENOENT by default
       // Act
@@ -224,7 +224,7 @@ describe('InstallService', () => {
     })
   })
 
-  describe('A3 — pre-existing unrelated rules survive', () => {
+  describe('pre-existing unrelated rules survive', () => {
     it('Given rules on non-overlapping globs, When installing, Then user content is preserved and our rules are appended', async () => {
       // Arrange
       readFileMocked.mockResolvedValue('* text=auto\n*.sh text\n')
@@ -239,7 +239,7 @@ describe('InstallService', () => {
     })
   })
 
-  describe('A4 — idempotent re-install', () => {
+  describe('idempotent re-install', () => {
     it('Given the attributes file already has every pattern with our driver, When installing, Then writeFile is NOT called (no spurious rewrite)', async () => {
       // Arrange — seed the file with exactly what an install would produce
       const seeded =
@@ -281,7 +281,7 @@ describe('InstallService', () => {
     })
   })
 
-  describe('A6 — conflict with another merge driver', () => {
+  describe('conflict with another merge driver', () => {
     it('Given another driver is already configured on one of our globs, When installing with abort policy, Then InstallConflictError is thrown and writeFile is NOT called', async () => {
       // Arrange
       readFileMocked.mockResolvedValue(

--- a/test/unit/service/InstallService.test.ts
+++ b/test/unit/service/InstallService.test.ts
@@ -217,4 +217,44 @@ describe('InstallService', () => {
       await expect(sut.installMergeDriver()).rejects.toThrow('EACCES')
     })
   })
+
+  describe('dry-run', () => {
+    it('Given dryRun=true on an empty repo, When installing, Then neither git config nor writeFile is called; the plan is returned', async () => {
+      // Arrange — default ENOENT for readFile
+      // Act
+      const outcome = await sut.installMergeDriver({ dryRun: true })
+
+      // Assert — nothing written, plan reflects a fresh install
+      expect(writeFileMocked).not.toHaveBeenCalled()
+      expect(mockedAddConfig).not.toHaveBeenCalled()
+      expect(outcome.dryRun).toBe(true)
+      expect(outcome.wroteAttributes).toBe(false)
+      // Every desired pattern shows up as `add`
+      const addPatterns = outcome.plan.actions.flatMap(a =>
+        a.kind === 'add' ? [a.pattern] : []
+      )
+      expect(addPatterns.length).toBe(
+        METADATA_TYPES_PATTERNS.length + MANIFEST_PATTERNS.length
+      )
+    })
+
+    it('Given dryRun=true with a conflicting file, When installing, Then InstallConflictError is NOT thrown (conflicts show in plan)', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act — dry run returns normally; no throw
+      const outcome = await sut.installMergeDriver({ dryRun: true })
+
+      // Assert — plan carries the conflict so the command can render it
+      const conflicts = outcome.plan.actions.flatMap(a =>
+        a.kind === 'conflict' ? [a] : []
+      )
+      expect(conflicts).toHaveLength(1)
+      expect(conflicts[0]?.existingDriver).toBe('some-other-tool')
+      expect(writeFileMocked).not.toHaveBeenCalled()
+      expect(mockedAddConfig).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/test/unit/service/InstallService.test.ts
+++ b/test/unit/service/InstallService.test.ts
@@ -7,6 +7,8 @@ import {
   METADATA_TYPES_PATTERNS,
 } from '../../../src/constant/metadataConstant.js'
 import {
+  DRIVER_COMMAND,
+  DRIVER_NAME_CONFIG_VALUE,
   InstallConflictError,
   InstallService,
 } from '../../../src/service/InstallService.js'
@@ -51,6 +53,20 @@ describe('InstallService', () => {
     readFileMocked.mockRejectedValue(ENOENT)
   })
 
+  describe('module-level DRIVER_COMMAND', () => {
+    it('has the expected shape: sh -c wrapper, forward-slash POSIX binary path, all 8 placeholders', () => {
+      // Kills path-escape regex mutations that would drop the
+      // forward-slash normalisation or strip quote escaping. Also
+      // pins the constant `DRIVER_NAME_CONFIG_VALUE` string so
+      // mutations like `this.name = ""` on derived values are caught.
+      expect(DRIVER_COMMAND).toMatch(
+        /^sh -c 'node ".+\/bin\/merge-driver\.cjs" -O "\$1" -A "\$2" -B "\$3" -P "\$4" -L "\$5" -S "\$6" -X "\$7" -Y "\$8"' -- %O %A %B %P %L %S %X %Y$/
+      )
+      expect(DRIVER_COMMAND).not.toMatch(/\\/) // no backslashes — POSIX path
+      expect(DRIVER_NAME_CONFIG_VALUE).toBe('Salesforce source merge driver')
+    })
+  })
+
   describe('git config', () => {
     it('Given any install invocation, When running, Then writes the two git-config entries exactly once', async () => {
       // Act
@@ -66,6 +82,18 @@ describe('InstallService', () => {
         `merge.${DRIVER_NAME}.driver`,
         expect.stringMatching(DRIVER_LINE_PATTERN)
       )
+    })
+
+    it('Given simpleGit is created, Then it receives { unsafe: { allowUnsafeMergeDriver: true } } so the sh -c driver is accepted', async () => {
+      // Act
+      await sut.installMergeDriver()
+
+      // Assert — the option matters: without it simple-git refuses to
+      // set driver commands that invoke sh. Exact-shape assertion so
+      // mutation drops of any key are caught.
+      expect(simpleGitMock).toHaveBeenCalledWith({
+        unsafe: { allowUnsafeMergeDriver: true },
+      })
     })
 
     it('Given the resolved binary path, When installing, Then it points at bin/merge-driver.cjs relative to the plugin root', async () => {
@@ -112,6 +140,35 @@ describe('InstallService', () => {
       expect(writeFileMocked).toHaveBeenCalledTimes(1)
       const [, content] = writeFileMocked.mock.calls[0] as [string, string]
       expect(content).toContain(`merge=${DRIVER_NAME}`)
+    })
+
+    it('Given a non-dry-run install, Then the outcome reports dryRun=false and wroteAttributes=true', async () => {
+      // Arrange — triggers write path
+      // Act
+      const outcome = await sut.installMergeDriver()
+
+      // Assert — explicit booleans; kills ReturnValue mutations that
+      // flip `dryRun: false` → `dryRun: true`.
+      expect(outcome.dryRun).toBe(false)
+      expect(outcome.wroteAttributes).toBe(true)
+    })
+
+    it('Given an idempotent re-install, Then wroteAttributes is false (no I/O)', async () => {
+      // Arrange — seed the file with every pattern already present
+      const seeded =
+        METADATA_TYPES_PATTERNS.map(
+          p => `*.${p}-meta.xml merge=${DRIVER_NAME}`
+        ).join('\n') +
+        '\n' +
+        MANIFEST_PATTERNS.map(p => `${p} merge=${DRIVER_NAME}`).join('\n') +
+        '\n'
+      readFileMocked.mockResolvedValue(seeded)
+
+      // Act
+      const outcome = await sut.installMergeDriver()
+
+      // Assert
+      expect(outcome.wroteAttributes).toBe(false)
     })
   })
 
@@ -204,6 +261,52 @@ describe('InstallService', () => {
         },
       ])
     })
+
+    it('Given a single conflict, Then the error message names the pattern, the other driver, and the total count', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act
+      const err = (await sut
+        .installMergeDriver()
+        .catch(e => e)) as InstallConflictError
+
+      // Assert — exact-message so mutations that gut the template
+      // literal (empty string, dropped lines.join, etc.) are caught.
+      expect(err.name).toBe('InstallConflictError')
+      expect(err.message).toBe(
+        'Installation aborted: 1 pattern(s) already configured with a different merge driver.\n  *.profile-meta.xml is already owned by merge=some-other-tool'
+      )
+    })
+
+    it('Given multiple conflicts, Then each pattern appears on its own line in the error message', async () => {
+      // Arrange — two patterns each owned by a different driver
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=tool-a\n*.permissionset-meta.xml merge=tool-b\n'
+      )
+
+      // Act
+      const err = (await sut
+        .installMergeDriver()
+        .catch(e => e)) as InstallConflictError
+
+      // Assert — newline-joined list; mutations that strip the join or
+      // the per-line formatter fail here.
+      expect(err.message).toContain(
+        '2 pattern(s) already configured with a different merge driver.'
+      )
+      expect(err.message).toContain(
+        '  *.profile-meta.xml is already owned by merge=tool-a'
+      )
+      expect(err.message).toContain(
+        '  *.permissionset-meta.xml is already owned by merge=tool-b'
+      )
+      // The two conflict lines are separated by a newline (not
+      // concatenated), which guards against `lines.join('')`.
+      expect(err.message).toMatch(/tool-a\n {2}\*\.permissionset-meta\.xml/)
+    })
   })
 
   describe('unexpected read errors', () => {
@@ -215,6 +318,33 @@ describe('InstallService', () => {
 
       // Act + Assert
       await expect(sut.installMergeDriver()).rejects.toThrow('EACCES')
+    })
+
+    it('Given readFile rejects with a bare string (not an object), When installing, Then the error propagates', async () => {
+      // Defensive — the ENOENT classifier narrows on `typeof err === 'object'`
+      // specifically. A string reject should bypass the fallback.
+      readFileMocked.mockRejectedValue('oops')
+      await expect(sut.installMergeDriver()).rejects.toBe('oops')
+    })
+
+    it('Given readFile rejects with null, When installing, Then the error propagates (null is not a readable Node error)', async () => {
+      // Kills the `err && …` and `typeof === object` mutations that would
+      // otherwise treat null as "missing file → fall back to empty".
+      readFileMocked.mockRejectedValue(null)
+      await expect(sut.installMergeDriver()).rejects.toBeNull()
+    })
+
+    it('Given readFile rejects ENOENT on a fresh repo, When installing, Then the fallback returns empty and writeFile creates the file populated with our patterns', async () => {
+      // Explicit ENOENT-handling assertion — kills the "Stryker was here!"
+      // string mutation on the fallback return value.
+      readFileMocked.mockRejectedValue(ENOENT)
+      await sut.installMergeDriver()
+      const [, content] = writeFileMocked.mock.calls[0] as [string, string]
+      // The fallback supplies '' which parses to an empty attributes
+      // file, so the resulting output must start cleanly with our
+      // first pattern (no "Stryker was here!" preamble, no stray
+      // prefix from a non-empty fallback).
+      expect(content.startsWith('*.')).toBe(true)
     })
   })
 

--- a/test/unit/service/InstallService.test.ts
+++ b/test/unit/service/InstallService.test.ts
@@ -7,11 +7,14 @@ import {
   METADATA_TYPES_PATTERNS,
 } from '../../../src/constant/metadataConstant.js'
 import {
+  applyInstallPlan,
   DRIVER_COMMAND,
   DRIVER_NAME_CONFIG_VALUE,
+  escapeBinaryPath,
   InstallConflictError,
   InstallService,
 } from '../../../src/service/InstallService.js'
+import { parse } from '../../../src/utils/gitAttributesFile.js'
 import { getGitAttributesPath } from '../../../src/utils/gitUtils.js'
 
 vi.mock('node:fs/promises')
@@ -53,6 +56,43 @@ describe('InstallService', () => {
     readFileMocked.mockRejectedValue(ENOENT)
   })
 
+  describe('escapeBinaryPath', () => {
+    it.each([
+      // [input, expected, reason]
+      ['/plain/path', '/plain/path', 'no escape needed'],
+      ['C:\\\\Users\\path', 'C://Users/path', 'Windows backslashes → POSIX'],
+      [
+        '/opt/%Alib/bin',
+        '/opt/%%Alib/bin',
+        'git placeholder letters MUST be protected',
+      ],
+      ['/opt/%%A/bin', '/opt/%%%%A/bin', 'existing %% also doubles (safe)'],
+      ['/tmp/$PATH', '/tmp/\\$PATH', 'dollar escaped (inner double-quotes)'],
+      [
+        '/tmp/`whoami`',
+        '/tmp/\\`whoami\\`',
+        'backtick escaped (command substitution)',
+      ],
+      [
+        '/tmp/with"quote',
+        '/tmp/with\\"quote',
+        'double-quote closes the inner "…" context',
+      ],
+      [
+        "/tmp/user's dir",
+        "/tmp/user'\\''s dir",
+        "single-quote escape via POSIX '\\'' idiom",
+      ],
+      [
+        '/a/$b`c"d\'e',
+        "/a/\\$b\\`c\\\"d'\\''e",
+        'all five shell-meta escapes compose',
+      ],
+    ])('Given path %j, When escaping, Then result is %j (%s)', (input, expected, _reason) => {
+      expect(escapeBinaryPath(input)).toBe(expected)
+    })
+  })
+
   describe('module-level DRIVER_COMMAND', () => {
     it('has the expected shape: sh -c wrapper, forward-slash POSIX binary path, all 8 placeholders', () => {
       // Kills path-escape regex mutations that would drop the
@@ -64,6 +104,18 @@ describe('InstallService', () => {
       )
       expect(DRIVER_COMMAND).not.toMatch(/\\/) // no backslashes — POSIX path
       expect(DRIVER_NAME_CONFIG_VALUE).toBe('Salesforce source merge driver')
+    })
+
+    it('the literal %O/%A/%B/%P/%L/%S/%X/%Y placeholder sequence appears EXACTLY once (the trailing `-- %O %A ...` list)', () => {
+      // Kills a subtle class of bug: if the binary path itself
+      // contains a literal `%A`-like sequence, git will substitute
+      // its merge-conflict file path there before spawning the
+      // shell, corrupting the command. The path-escape chain now
+      // doubles `%` to `%%`, so the placeholder sequence must still
+      // appear exactly once in the final command string — the
+      // trailing ` -- %O %A %B %P %L %S %X %Y` list that git expands.
+      const matches = DRIVER_COMMAND.match(/%[OABPLSXY]/g) ?? []
+      expect(matches).toEqual(['%O', '%A', '%B', '%P', '%L', '%S', '%X', '%Y'])
     })
   })
 
@@ -306,6 +358,36 @@ describe('InstallService', () => {
       // The two conflict lines are separated by a newline (not
       // concatenated), which guards against `lines.join('')`.
       expect(err.message).toMatch(/tool-a\n {2}\*\.permissionset-meta\.xml/)
+    })
+  })
+
+  describe('defensive: overwrite action pointing at a non-rule line', () => {
+    it('Given a hand-crafted plan whose overwrite points at a comment line, When applying, Then applyInstallPlan throws with a clear message (future-proofs the planner contract)', () => {
+      // Arrange — comment at index 0, not a rule. A real plan from
+      // `planInstall` would never do this, but if the planner ever
+      // changes and emits `overwrite` for a non-rule index, the
+      // guard in applyInstallPlan prevents a silent .attrs-undefined
+      // crash inside ruleWithAttr.
+      const parsed = parse('# just a comment\n')
+      const badPlan = {
+        actions: [
+          {
+            kind: 'overwrite' as const,
+            pattern: '*.profile-meta.xml',
+            existingDriver: 'other',
+            lineIndex: 0,
+            originalRaw: '*.profile-meta.xml merge=other',
+          },
+        ],
+        dedupDrops: [],
+        textAttributeWarnings: [],
+        commentedOutWarnings: [],
+      }
+
+      // Act + Assert
+      expect(() => applyInstallPlan(parsed, badPlan)).toThrow(
+        /planInstall emitted 'overwrite' for non-rule line/
+      )
     })
   })
 

--- a/test/unit/service/InstallService.test.ts
+++ b/test/unit/service/InstallService.test.ts
@@ -218,6 +218,88 @@ describe('InstallService', () => {
     })
   })
 
+  describe('on-conflict=skip', () => {
+    it('Given another driver on our glob, When installing with onConflict=skip, Then the conflicting line is left untouched and no error is thrown', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act
+      await sut.installMergeDriver({ onConflict: 'skip' })
+
+      // Assert — file may still be written (to add the rest of our
+      // patterns), but the user's line is untouched
+      expect(writeFileMocked).toHaveBeenCalled()
+      const [, content] = writeFileMocked.mock.calls[0] as [string, string]
+      expect(content).toContain('*.profile-meta.xml merge=some-other-tool')
+      // And our driver was NOT added for that glob — the user's line wins
+      const ourProfileLines = content
+        .split('\n')
+        .filter(l => l === `*.profile-meta.xml merge=${DRIVER_NAME}`)
+      expect(ourProfileLines).toHaveLength(0)
+    })
+  })
+
+  describe('on-conflict=overwrite', () => {
+    it('Given another driver on our glob, When installing with onConflict=overwrite, Then the user line is replaced with our driver AND an annotation comment records the original raw', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act
+      await sut.installMergeDriver({ onConflict: 'overwrite' })
+
+      // Assert
+      expect(writeFileMocked).toHaveBeenCalled()
+      const [, content] = writeFileMocked.mock.calls[0] as [string, string]
+      // Annotation above, our driver on the replaced line
+      expect(content).toContain(
+        '# sf-git-merge-driver overwrote: *.profile-meta.xml merge=some-other-tool'
+      )
+      expect(content).toContain(`*.profile-meta.xml merge=${DRIVER_NAME}`)
+      // Original user line is gone (replaced)
+      const originalLines = content
+        .split('\n')
+        .filter(l => l === '*.profile-meta.xml merge=some-other-tool')
+      expect(originalLines).toHaveLength(0)
+    })
+  })
+
+  describe('round-trip — overwrite install + uninstall restores user driver', () => {
+    // This is the critical contract for the overwrite policy: after
+    // overwrite-then-uninstall, the file looks as if we were never there.
+    it("Given overwrite install then uninstall with the same attributes file, Then the user's original driver line is restored", async () => {
+      // Use real fs flow in-process via the parse/planner helpers.
+      // We simulate the install by running the service with a mock
+      // readFile, capturing the written content, then feeding that
+      // content back into the uninstall planner.
+      const seed = '*.profile-meta.xml merge=some-other-tool\n'
+      readFileMocked.mockResolvedValue(seed)
+      await sut.installMergeDriver({ onConflict: 'overwrite' })
+      const [, afterInstall] = writeFileMocked.mock.calls[0] as [string, string]
+      expect(afterInstall).toContain('# sf-git-merge-driver overwrote:')
+
+      // Simulate uninstall reading the same content we just wrote.
+      const { UninstallService } = await import(
+        '../../../src/service/UninstallService.js'
+      )
+      readFileMocked.mockReset()
+      readFileMocked.mockResolvedValue(afterInstall)
+      writeFileMocked.mockClear()
+      await new UninstallService().uninstallMergeDriver()
+      const [, afterUninstall] = writeFileMocked.mock.calls[0] as [
+        string,
+        string,
+      ]
+
+      // Assert — the user's original line is back, annotation + our
+      // driver line are gone.
+      expect(afterUninstall).toBe(seed)
+    })
+  })
+
   describe('dry-run', () => {
     it('Given dryRun=true on an empty repo, When installing, Then neither git config nor writeFile is called; the plan is returned', async () => {
       // Arrange — default ENOENT for readFile

--- a/test/unit/service/InstallService.test.ts
+++ b/test/unit/service/InstallService.test.ts
@@ -1,4 +1,4 @@
-import { appendFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import simpleGit from 'simple-git'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { DRIVER_NAME } from '../../../src/constant/driverConstant.js'
@@ -6,84 +6,215 @@ import {
   MANIFEST_PATTERNS,
   METADATA_TYPES_PATTERNS,
 } from '../../../src/constant/metadataConstant.js'
-import { InstallService } from '../../../src/service/InstallService.js'
+import {
+  InstallConflictError,
+  InstallService,
+} from '../../../src/service/InstallService.js'
 import { getGitAttributesPath } from '../../../src/utils/gitUtils.js'
 
 vi.mock('node:fs/promises')
 vi.mock('simple-git')
 vi.mock('../../../src/utils/gitUtils.js')
 
+const GIT_ATTRIBUTES_PATH = '.git/info/attributes'
+
 const mockedAddConfig = vi.fn()
-const simpleGitMock = simpleGit as Mock
+const simpleGitMock = simpleGit as unknown as Mock
 simpleGitMock.mockReturnValue({
   addConfig: mockedAddConfig,
 })
 
 const getGitAttributesPathMocked = getGitAttributesPath as Mock
-const appendFileMocked = vi.mocked(appendFile)
+const readFileMocked = vi.mocked(readFile) as Mock
+const writeFileMocked = vi.mocked(writeFile)
 
-// Shape the new driver line must match. The absolute path is resolved at
+// Shape the driver line must match. The absolute path is resolved at
 // InstallService module load via import.meta.url; we assert its suffix and
 // the 8-placeholder layout (including %S) rather than the full string.
 const DRIVER_LINE_PATTERN =
   /^sh -c 'node ".+\/bin\/merge-driver\.cjs" -O "\$1" -A "\$2" -B "\$3" -P "\$4" -L "\$5" -S "\$6" -X "\$7" -Y "\$8"' -- %O %A %B %P %L %S %X %Y$/
 
+// ENOENT shape returned by fs.readFile when the file doesn't exist.
+const ENOENT = Object.assign(new Error('ENOENT: no such file'), {
+  code: 'ENOENT',
+})
+
 describe('InstallService', () => {
-  let sut: InstallService // System Under Test
+  let sut: InstallService
 
   beforeEach(() => {
     sut = new InstallService()
-    mockedAddConfig.mockClear()
-    appendFileMocked.mockClear()
-    getGitAttributesPathMocked.mockResolvedValue('.git/info/attributes')
+    mockedAddConfig.mockReset()
+    readFileMocked.mockReset()
+    writeFileMocked.mockReset()
+    getGitAttributesPathMocked.mockResolvedValue(GIT_ATTRIBUTES_PATH)
+    readFileMocked.mockRejectedValue(ENOENT)
   })
 
-  it('Given a clean repo, When installing, Then git config and .gitattributes are written with the new binary-driver line', async () => {
-    // Act
-    await sut.installMergeDriver()
+  describe('git config', () => {
+    it('Given any install invocation, When running, Then writes the two git-config entries exactly once', async () => {
+      // Act
+      await sut.installMergeDriver()
 
-    // Assert — git open
-    expect(getGitAttributesPathMocked).toHaveBeenCalledTimes(1)
-    expect(simpleGitMock).toHaveBeenCalledWith({
-      unsafe: { allowUnsafeMergeDriver: true },
+      // Assert — two entries, no duplication via --add
+      expect(mockedAddConfig).toHaveBeenCalledTimes(2)
+      expect(mockedAddConfig).toHaveBeenCalledWith(
+        `merge.${DRIVER_NAME}.name`,
+        'Salesforce source merge driver'
+      )
+      expect(mockedAddConfig).toHaveBeenCalledWith(
+        `merge.${DRIVER_NAME}.driver`,
+        expect.stringMatching(DRIVER_LINE_PATTERN)
+      )
     })
 
-    // Assert — two git config entries (name + driver)
-    expect(mockedAddConfig).toHaveBeenCalledTimes(2)
-    expect(mockedAddConfig).toHaveBeenCalledWith(
-      `merge.${DRIVER_NAME}.name`,
-      'Salesforce source merge driver'
-    )
-    expect(mockedAddConfig).toHaveBeenCalledWith(
-      `merge.${DRIVER_NAME}.driver`,
-      expect.stringMatching(DRIVER_LINE_PATTERN)
-    )
+    it('Given the resolved binary path, When installing, Then it points at bin/merge-driver.cjs relative to the plugin root', async () => {
+      // Act
+      await sut.installMergeDriver()
 
-    // Assert — .gitattributes append
-    expect(appendFileMocked).toHaveBeenCalledTimes(1)
-    const expectedMetadataPatterns = METADATA_TYPES_PATTERNS.map(
-      pattern => `*.${pattern}-meta.xml merge=${DRIVER_NAME}`
-    ).join('\n')
-    const expectedManifestPatterns = MANIFEST_PATTERNS.map(
-      pattern => `${pattern} merge=${DRIVER_NAME}`
-    ).join('\n')
-    const expectedContent = `${expectedMetadataPatterns}\n${expectedManifestPatterns}\n`
-    expect(appendFileMocked).toHaveBeenCalledWith(
-      '.git/info/attributes',
-      expectedContent,
-      { flag: 'a' }
-    )
+      // Assert
+      const driverCall = mockedAddConfig.mock.calls.find(
+        ([key]) => key === `merge.${DRIVER_NAME}.driver`
+      )
+      expect(driverCall).toBeDefined()
+      const driverLine = driverCall?.[1] as string
+      expect(driverLine).toMatch(/ ".+\/bin\/merge-driver\.cjs"/)
+    })
   })
 
-  it('Given the resolved binary path, When installing, Then it points at bin/merge-driver.cjs relative to the plugin root', async () => {
-    await sut.installMergeDriver()
-    const driverCall = mockedAddConfig.mock.calls.find(
-      ([key]) => key === `merge.${DRIVER_NAME}.driver`
-    )
-    expect(driverCall).toBeDefined()
-    const driverLine = driverCall?.[1] as string
-    // Absolute path, ends with /bin/merge-driver.cjs, wrapped in double quotes.
-    // On Windows the POSIX normalization produces D:/a/... (drive letter, forward slashes).
-    expect(driverLine).toMatch(/ ".+\/bin\/merge-driver\.cjs"/)
+  describe('A1/A2 — fresh install (attributes file missing or empty)', () => {
+    it('Given the attributes file does not exist, When installing, Then writeFile creates it with every desired pattern', async () => {
+      // Arrange — readFile already rejects with ENOENT by default
+      // Act
+      await sut.installMergeDriver()
+
+      // Assert
+      expect(writeFileMocked).toHaveBeenCalledTimes(1)
+      const [path, content] = writeFileMocked.mock.calls[0] as [string, string]
+      expect(path).toBe(GIT_ATTRIBUTES_PATH)
+      // Every metadata + manifest pattern is present exactly once, with our driver.
+      for (const pattern of METADATA_TYPES_PATTERNS) {
+        expect(content).toContain(`*.${pattern}-meta.xml merge=${DRIVER_NAME}`)
+      }
+      for (const pattern of MANIFEST_PATTERNS) {
+        expect(content).toContain(`${pattern} merge=${DRIVER_NAME}`)
+      }
+    })
+
+    it('Given an empty attributes file, When installing, Then writeFile is called with populated content', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue('')
+
+      // Act
+      await sut.installMergeDriver()
+
+      // Assert
+      expect(writeFileMocked).toHaveBeenCalledTimes(1)
+      const [, content] = writeFileMocked.mock.calls[0] as [string, string]
+      expect(content).toContain(`merge=${DRIVER_NAME}`)
+    })
+  })
+
+  describe('A3 — pre-existing unrelated rules survive', () => {
+    it('Given rules on non-overlapping globs, When installing, Then user content is preserved and our rules are appended', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue('* text=auto\n*.sh text\n')
+
+      // Act
+      await sut.installMergeDriver()
+
+      // Assert
+      const [, content] = writeFileMocked.mock.calls[0] as [string, string]
+      expect(content.startsWith('* text=auto\n*.sh text\n')).toBe(true)
+      expect(content).toContain(`*.profile-meta.xml merge=${DRIVER_NAME}`)
+    })
+  })
+
+  describe('A4 — idempotent re-install', () => {
+    it('Given the attributes file already has every pattern with our driver, When installing, Then writeFile is NOT called (no spurious rewrite)', async () => {
+      // Arrange — seed the file with exactly what an install would produce
+      const seeded =
+        METADATA_TYPES_PATTERNS.map(
+          p => `*.${p}-meta.xml merge=${DRIVER_NAME}`
+        ).join('\n') +
+        '\n' +
+        MANIFEST_PATTERNS.map(p => `${p} merge=${DRIVER_NAME}`).join('\n') +
+        '\n'
+      readFileMocked.mockResolvedValue(seeded)
+
+      // Act
+      await sut.installMergeDriver()
+
+      // Assert — git config is still updated (idempotent), but the file is untouched
+      expect(writeFileMocked).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('dedup — legacy duplicate lines', () => {
+    it('Given a pattern appears twice with our driver, When installing, Then the duplicate is silently dropped from the written output', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        `*.profile-meta.xml merge=${DRIVER_NAME}\n*.profile-meta.xml merge=${DRIVER_NAME}\n`
+      )
+
+      // Act
+      await sut.installMergeDriver()
+
+      // Assert — writeFile called, result has exactly one copy of the pattern
+      expect(writeFileMocked).toHaveBeenCalledTimes(1)
+      const [, content] = writeFileMocked.mock.calls[0] as [string, string]
+      const count = content
+        .split('\n')
+        .filter(
+          line => line === `*.profile-meta.xml merge=${DRIVER_NAME}`
+        ).length
+      expect(count).toBe(1)
+    })
+  })
+
+  describe('A6 — conflict with another merge driver', () => {
+    it('Given another driver is already configured on one of our globs, When installing with abort policy, Then InstallConflictError is thrown and writeFile is NOT called', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act + Assert
+      await expect(sut.installMergeDriver()).rejects.toBeInstanceOf(
+        InstallConflictError
+      )
+      expect(writeFileMocked).not.toHaveBeenCalled()
+    })
+
+    it('Given the conflict error, Then it surfaces the pattern and existing driver so the command layer can show the user', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=some-other-tool\n'
+      )
+
+      // Act
+      const err = await sut.installMergeDriver().catch(e => e)
+
+      // Assert
+      expect(err).toBeInstanceOf(InstallConflictError)
+      expect((err as InstallConflictError).conflicts).toEqual([
+        {
+          pattern: '*.profile-meta.xml',
+          existingDriver: 'some-other-tool',
+        },
+      ])
+    })
+  })
+
+  describe('unexpected read errors', () => {
+    it('Given readFile throws a non-ENOENT error, When installing, Then the error propagates (no silent fallback)', async () => {
+      // Arrange
+      readFileMocked.mockRejectedValue(
+        Object.assign(new Error('EACCES'), { code: 'EACCES' })
+      )
+
+      // Act + Assert
+      await expect(sut.installMergeDriver()).rejects.toThrow('EACCES')
+    })
   })
 })

--- a/test/unit/service/UninstallService.test.ts
+++ b/test/unit/service/UninstallService.test.ts
@@ -2,7 +2,11 @@ import { readFile, writeFile } from 'node:fs/promises'
 import simpleGit from 'simple-git'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { DRIVER_NAME } from '../../../src/constant/driverConstant.js'
-import { UninstallService } from '../../../src/service/UninstallService.js'
+import {
+  applyUninstallPlan,
+  UninstallService,
+} from '../../../src/service/UninstallService.js'
+import { parse } from '../../../src/utils/gitAttributesFile.js'
 import { getGitAttributesPath } from '../../../src/utils/gitUtils.js'
 import { Logger } from '../../../src/utils/LoggingService.js'
 
@@ -188,6 +192,36 @@ describe('UninstallService', () => {
         // Assert — no plan actions means no file rewrite
         expect(writeFile).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('defensive: restore-overwrite with empty originalRaw (planner contract breach)', () => {
+    it('Given a hand-crafted plan whose restore-overwrite carries an empty originalRaw, When applying, Then the original line is preserved (not replaced with undefined)', () => {
+      // The real planner rejects empty annotation bodies, but if a
+      // future change emits restore-overwrite with no content,
+      // `parse('').lines[0]` is undefined. The defensive fallback
+      // preserves the incoming line so the serialise stage never
+      // dereferences `undefined.raw`.
+      const parsed = parse('*.profile-meta.xml merge=salesforce-source\n')
+      const badPlan = {
+        actions: [
+          {
+            kind: 'restore-overwrite' as const,
+            lineIndex: 0,
+            originalRaw: '',
+          },
+        ],
+      }
+
+      // Act
+      const nextLines = applyUninstallPlan(parsed.lines, badPlan)
+
+      // Assert — the incoming line is kept verbatim (no undefined).
+      expect(nextLines).toHaveLength(1)
+      expect(nextLines[0]?.kind).toBe('rule')
+      expect(nextLines[0]?.raw).toBe(
+        '*.profile-meta.xml merge=salesforce-source'
+      )
     })
   })
 

--- a/test/unit/service/UninstallService.test.ts
+++ b/test/unit/service/UninstallService.test.ts
@@ -147,7 +147,7 @@ describe('UninstallService', () => {
     })
   })
 
-  describe('A8 — combined line with user attributes + our merge', () => {
+  describe('combined line with user attributes + our merge', () => {
     it('Given a line like `*.profile-meta.xml text=auto merge=salesforce-source`, When uninstalling, Then the user attributes survive and only `merge=...` is stripped', () => {
       // Arrange — regression fix: the old regex deleted the whole line,
       // destroying the user's `text=auto`.
@@ -169,7 +169,7 @@ describe('UninstallService', () => {
     })
   })
 
-  describe('A10 — CRLF preservation on Windows-flavoured files', () => {
+  describe('CRLF preservation on Windows-flavoured files', () => {
     it('Given a CRLF-terminated attributes file, When uninstalling, Then the output keeps CRLF endings (no mixed LF/CRLF)', () => {
       // Arrange
       readFileMocked.mockResolvedValue(

--- a/test/unit/service/UninstallService.test.ts
+++ b/test/unit/service/UninstallService.test.ts
@@ -150,4 +150,29 @@ describe('UninstallService', () => {
       })
     })
   })
+
+  describe('dry-run', () => {
+    it('Given dryRun=true, When uninstalling, Then git config is NOT touched, writeFile is NOT called, and the plan is returned', async () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml merge=salesforce-source\n*.profile-meta.xml text=auto merge=salesforce-source\n'
+      )
+
+      // Act
+      const outcome = await sut.uninstallMergeDriver({ dryRun: true })
+
+      // Assert — side effects suppressed
+      expect(mockedRaw).not.toHaveBeenCalled()
+      expect(writeFile).not.toHaveBeenCalled()
+
+      // Assert — plan preview available: one drop, one rewrite
+      expect(outcome.dryRun).toBe(true)
+      expect(outcome.wroteAttributes).toBe(false)
+      expect(outcome.removedConfigSection).toBe(false)
+      expect(outcome.plan.actions).toEqual([
+        { kind: 'drop-line', lineIndex: 0 },
+        { kind: 'remove-merge-attr', lineIndex: 1 },
+      ])
+    })
+  })
 })

--- a/test/unit/service/UninstallService.test.ts
+++ b/test/unit/service/UninstallService.test.ts
@@ -4,10 +4,27 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { DRIVER_NAME } from '../../../src/constant/driverConstant.js'
 import { UninstallService } from '../../../src/service/UninstallService.js'
 import { getGitAttributesPath } from '../../../src/utils/gitUtils.js'
+import { Logger } from '../../../src/utils/LoggingService.js'
 
 vi.mock('node:fs/promises')
 vi.mock('simple-git')
 vi.mock('../../../src/utils/gitUtils.js')
+vi.mock('../../../src/utils/LoggingService.js', async importOriginal => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../src/utils/LoggingService.js')
+    >()
+  return {
+    ...actual,
+    Logger: {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+})
 
 const GIT_ATTRIBUTES_PATH = '.git/info/attributes'
 const ATTRIBUTES_CONTENT = `*.xml merge=salesforce-source\nsome other content`
@@ -66,6 +83,18 @@ describe('UninstallService', () => {
         FILTERED_CONTENT
       )
     })
+
+    it('then the outcome reports wroteAttributes=true and removedConfigSection=true', async () => {
+      // Act
+      const outcome = await sut.uninstallMergeDriver()
+
+      // Assert — explicit boolean pins so mutants flipping true→false
+      // on the flag assignments are killed.
+      expect(outcome.removedConfigSection).toBe(true)
+      expect(outcome.wroteAttributes).toBe(true)
+      expect(outcome.dryRun).toBe(false)
+      expect(outcome.gitAttributesPath).toBe(GIT_ATTRIBUTES_PATH)
+    })
   })
 
   describe('given config cleanup fails when uninstalling', () => {
@@ -85,15 +114,26 @@ describe('UninstallService', () => {
   })
 
   describe('given both config and attributes cleanup fail when uninstalling', () => {
-    it('then fails silently', async () => {
+    it('then fails silently AND both errors are logged with their distinct prefixes', async () => {
       // Arrange
-      mockedRaw.mockRejectedValue(new Error('Failed to cleanup git config'))
-      readFileMocked.mockRejectedValue(
-        new Error('Failed to cleanup git attributes')
-      )
+      const configError = new Error('Failed to cleanup git config')
+      const attrsError = new Error('Failed to cleanup git attributes')
+      mockedRaw.mockRejectedValue(configError)
+      readFileMocked.mockRejectedValue(attrsError)
 
-      // Act & Assert
+      // Act
       await expect(sut.uninstallMergeDriver()).resolves.not.toThrow()
+
+      // Assert — exact log-message prefixes guard against mutants that
+      // gut the string literals to "".
+      expect(Logger.error).toHaveBeenCalledWith(
+        'Merge driver uninstallation failed to cleanup git config',
+        configError
+      )
+      expect(Logger.error).toHaveBeenCalledWith(
+        'Merge driver uninstallation failed to cleanup git attributes',
+        attrsError
+      )
     })
   })
 

--- a/test/unit/service/UninstallService.test.ts
+++ b/test/unit/service/UninstallService.test.ts
@@ -96,4 +96,58 @@ describe('UninstallService', () => {
       await expect(sut.uninstallMergeDriver()).resolves.not.toThrow()
     })
   })
+
+  describe('A8 — combined line with user attributes + our merge', () => {
+    it('Given a line like `*.profile-meta.xml text=auto merge=salesforce-source`, When uninstalling, Then the user attributes survive and only `merge=...` is stripped', () => {
+      // Arrange — regression fix: the old regex deleted the whole line,
+      // destroying the user's `text=auto`.
+      readFileMocked.mockResolvedValue(
+        '*.profile-meta.xml text=auto eol=lf merge=salesforce-source\n'
+      )
+
+      // Act
+      return sut.uninstallMergeDriver().then(() => {
+        // Assert
+        expect(writeFile).toHaveBeenCalledTimes(1)
+        const written = (writeFile as unknown as Mock).mock
+          .calls[0][1] as string
+        expect(written).toContain('*.profile-meta.xml')
+        expect(written).toContain('text=auto')
+        expect(written).toContain('eol=lf')
+        expect(written).not.toContain('merge=salesforce-source')
+      })
+    })
+  })
+
+  describe('A10 — CRLF preservation on Windows-flavoured files', () => {
+    it('Given a CRLF-terminated attributes file, When uninstalling, Then the output keeps CRLF endings (no mixed LF/CRLF)', () => {
+      // Arrange
+      readFileMocked.mockResolvedValue(
+        '* text=auto\r\n*.profile-meta.xml merge=salesforce-source\r\n'
+      )
+
+      // Act
+      return sut.uninstallMergeDriver().then(() => {
+        // Assert
+        const written = (writeFile as unknown as Mock).mock
+          .calls[0][1] as string
+        expect(written).toBe('* text=auto\r\n')
+        // Sanity check: no stray LF-only terminators
+        expect(written).not.toMatch(/[^\r]\n/)
+      })
+    })
+  })
+
+  describe('no-op — attributes file has no driver lines', () => {
+    it('Given an attributes file that does not reference our driver, When uninstalling, Then writeFile is NOT called (no spurious rewrites)', () => {
+      // Arrange
+      readFileMocked.mockResolvedValue('* text=auto\n*.sh text\n')
+
+      // Act
+      return sut.uninstallMergeDriver().then(() => {
+        // Assert — no plan actions means no file rewrite
+        expect(writeFile).not.toHaveBeenCalled()
+      })
+    })
+  })
 })

--- a/test/unit/service/UninstallService.test.ts
+++ b/test/unit/service/UninstallService.test.ts
@@ -66,17 +66,6 @@ describe('UninstallService', () => {
       ])
     })
 
-    it('then reads git attributes file', async () => {
-      // Act
-      await sut.uninstallMergeDriver()
-
-      // Assert
-      expect(readFile).toHaveBeenCalledWith(
-        GIT_ATTRIBUTES_PATH,
-        expect.anything()
-      )
-    })
-
     it('then writes filtered content back', async () => {
       // Act
       await sut.uninstallMergeDriver()
@@ -137,6 +126,23 @@ describe('UninstallService', () => {
       expect(Logger.error).toHaveBeenCalledWith(
         'Merge driver uninstallation failed to cleanup git attributes',
         attrsError
+      )
+    })
+  })
+
+  describe('given writeFile fails when persisting the filtered attributes', () => {
+    it('then the error propagates to the caller (not swallowed by the read-phase catch)', async () => {
+      // Arrange — read-phase succeeds, write-phase fails. Regression
+      // guard: an earlier implementation wrapped writeFile in the
+      // same try/catch as readFile, logging and returning success;
+      // that masked an inconsistent state where the git config
+      // section was gone but the attributes file still referenced it.
+      const writeError = new Error('EACCES: permission denied')
+      vi.mocked(writeFile).mockRejectedValueOnce(writeError)
+
+      // Act / Assert
+      await expect(sut.uninstallMergeDriver()).rejects.toThrow(
+        'EACCES: permission denied'
       )
     })
   })
@@ -217,6 +223,39 @@ describe('UninstallService', () => {
       const nextLines = applyUninstallPlan(parsed.lines, badPlan)
 
       // Assert — the incoming line is kept verbatim (no undefined).
+      expect(nextLines).toHaveLength(1)
+      expect(nextLines[0]?.kind).toBe('rule')
+      expect(nextLines[0]?.raw).toBe(
+        '*.profile-meta.xml merge=salesforce-source'
+      )
+    })
+  })
+
+  describe('defensive: restore-overwrite with multi-line originalRaw (planner contract breach)', () => {
+    it('Given a hand-crafted plan whose restore-overwrite carries an embedded newline, When applying, Then the original line is preserved (not silently restored with only the first split segment)', () => {
+      // The planner captures `originalRaw` from a single parsed rule
+      // line, which cannot contain a newline. A hand-crafted plan
+      // with an embedded `\n` would otherwise cause `parse(...).lines[0]`
+      // to restore only the first segment, silently discarding the
+      // rest — a partial restore masquerading as a successful one.
+      // The `length === 1` guard keeps the incoming line instead.
+      const parsed = parse('*.profile-meta.xml merge=salesforce-source\n')
+      const badPlan = {
+        actions: [
+          {
+            kind: 'restore-overwrite' as const,
+            lineIndex: 0,
+            originalRaw: '*.a merge=tool-a\n*.b merge=tool-b',
+          },
+        ],
+      }
+
+      // Act
+      const nextLines = applyUninstallPlan(parsed.lines, badPlan)
+
+      // Assert — the incoming line is kept verbatim. If the guard
+      // were removed, `restored` would be the parsed `*.a merge=tool-a`,
+      // silently losing `*.b merge=tool-b`.
       expect(nextLines).toHaveLength(1)
       expect(nextLines[0]?.kind).toBe('rule')
       expect(nextLines[0]?.raw).toBe(

--- a/test/unit/utils/gitAttributesFile.test.ts
+++ b/test/unit/utils/gitAttributesFile.test.ts
@@ -4,6 +4,7 @@ import {
   addRule,
   getMerge,
   parse,
+  ruleWithAttr,
   ruleWithoutAttr,
   serialise,
 } from '../../../src/utils/gitAttributesFile.js'
@@ -435,6 +436,53 @@ describe('gitAttributesFile helpers', () => {
       if (rule.kind !== 'rule') throw new Error('unreachable')
       const next = ruleWithoutAttr(rule, 'merge')
       expect(next.raw).toBe('*.profile-meta.xml -text')
+    })
+  })
+
+  describe('ruleWithAttr', () => {
+    it('Given a rule without the attribute, When setting it, Then the raw gains the new token at the end', () => {
+      // Arrange
+      const rule = parse('*.profile-meta.xml text=auto\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithAttr(rule, 'merge', 'salesforce-source')
+      expect(next.attrs.get('merge')).toBe('salesforce-source')
+      expect(next.raw).toBe(
+        '*.profile-meta.xml text=auto merge=salesforce-source'
+      )
+    })
+
+    it('Given a rule that already has the attribute, When setting it again, Then the existing value is replaced (no duplicate token)', () => {
+      // Arrange — overwrite from some-other-tool to salesforce-source
+      const rule = parse('*.profile-meta.xml merge=some-other-tool\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithAttr(rule, 'merge', 'salesforce-source')
+      expect(next.attrs.get('merge')).toBe('salesforce-source')
+      const mergeTokens = next.raw.match(/merge=/g) ?? []
+      expect(mergeTokens).toHaveLength(1)
+    })
+
+    it('Given a rule, When setting a bare-true attribute, Then the raw ends with the attr name alone', () => {
+      // Arrange
+      const rule = parse('* text=auto\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithAttr(rule, 'binary', true)
+      expect(next.raw).toBe('* text=auto binary')
+    })
+
+    it('Given a rule, When setting a negated attribute, Then the raw uses the "-attr" form', () => {
+      // Arrange
+      const rule = parse('* text=auto\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithAttr(rule, 'executable', false)
+      expect(next.raw).toBe('* text=auto -executable')
     })
   })
 })

--- a/test/unit/utils/gitAttributesFile.test.ts
+++ b/test/unit/utils/gitAttributesFile.test.ts
@@ -4,6 +4,7 @@ import {
   addRule,
   getMerge,
   parse,
+  ruleWithoutAttr,
   serialise,
 } from '../../../src/utils/gitAttributesFile.js'
 
@@ -396,6 +397,44 @@ describe('gitAttributesFile helpers', () => {
 
       // Assert
       expect(out).toContain('*.bin -text')
+    })
+  })
+
+  describe('ruleWithoutAttr', () => {
+    it('Given a rule with merge + string attr, When removing merge, Then the rule keeps the string attr and drops merge', () => {
+      // Arrange
+      const rule = parse(
+        '*.profile-meta.xml text=auto merge=salesforce-source\n'
+      ).lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithoutAttr(rule, 'merge')
+      expect(next.attrs.has('merge')).toBe(false)
+      expect(next.attrs.get('text')).toBe('auto')
+      expect(next.raw).toBe('*.profile-meta.xml text=auto')
+    })
+
+    it('Given a rule with merge + bare-true attr, When removing merge, Then the raw serialises the bare attr correctly', () => {
+      // Arrange
+      const rule = parse('*.profile-meta.xml binary merge=salesforce-source\n')
+        .lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithoutAttr(rule, 'merge')
+      expect(next.raw).toBe('*.profile-meta.xml binary')
+    })
+
+    it('Given a rule with merge + negated attr, When removing merge, Then the raw serialises the negated attr correctly', () => {
+      // Arrange
+      const rule = parse('*.profile-meta.xml -text merge=salesforce-source\n')
+        .lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      const next = ruleWithoutAttr(rule, 'merge')
+      expect(next.raw).toBe('*.profile-meta.xml -text')
     })
   })
 })

--- a/test/unit/utils/gitAttributesFile.test.ts
+++ b/test/unit/utils/gitAttributesFile.test.ts
@@ -87,6 +87,19 @@ describe('gitAttributesFile.parse', () => {
       expect(sut.hasTrailingNewline).toBe(false)
       expect(sut.lines).toHaveLength(1)
     })
+
+    it('Given a non-empty string with NO newline at all, When parsing, Then falls back to os.EOL', () => {
+      // Kills ConditionalExpression mutants on `if (text.includes('\n'))`
+      // and the StringLiteral mutant `text.includes('')`.
+      const input = '* text=auto'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert — on POSIX EOL is '\n'; on Windows it's '\r\n'. Assert
+      // the contract abstractly: the returned EOL is os.EOL.
+      expect(sut.eol).toBe(EOL)
+    })
   })
 
   describe('rule parsing', () => {
@@ -176,8 +189,102 @@ describe('gitAttributesFile.parse', () => {
       expect(rule.pattern).toBe('*.profile-meta.xml')
     })
 
-    it('Given multiple whitespace separators, When parsing, Then tokenises correctly', () => {
-      // Arrange
+    it('Given an unquoted pattern, When parsing, Then no quotes are stripped (pattern stays as-is)', () => {
+      // Arrange — guards the two StringLiteral mutants on the
+      // `startsWith('"') && endsWith('"')` checks by proving both
+      // sides of the conditional fire when quotes ARE present and
+      // neither incorrectly fires when they aren't.
+      const input = '*.profile-meta.xml merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('*.profile-meta.xml')
+      // Sanity: the literal double-quote is NOT part of the pattern
+      expect(rule.pattern.includes('"')).toBe(false)
+    })
+
+    it('Given a pattern starting with " but not ending with " (malformed quoting), When parsing, Then the quote is preserved (no half-strip)', () => {
+      // Kills the endsWith('"') → endsWith("") mutation, which would
+      // make every pattern look quote-terminated and wrongly strip.
+      const input = '"*.profile-meta.xml merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern.startsWith('"')).toBe(true)
+    })
+
+    it('Given a pattern ending with " but not starting with " (malformed quoting), When parsing, Then the quote is preserved', () => {
+      // Kills the startsWith('"') → startsWith("") mutation.
+      const input = '*.profile-meta.xml" merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern.endsWith('"')).toBe(true)
+    })
+
+    it('Given a single-character quoted pattern "x", When parsing, Then quotes ARE stripped (length 3 passes >= 2)', () => {
+      // Kills the `>= 2` → `> 2` mutation by asserting stripping works
+      // at the boundary. "x" has length 3, well above 2.
+      const input = '"x" merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('x')
+    })
+
+    it("Given a one-character pattern '\"' (length 1), When parsing, Then it is NOT mistaken for an empty quoted pattern", () => {
+      // Kills the `pattern.length >= 2` guard mutations: without it,
+      // `startsWith('"') && endsWith('"')` would both be true for the
+      // single-character string `"` and the slice(1, -1) would produce
+      // an empty pattern. The >=2 guard prevents this.
+      const input = '" merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert — the literal `"` stays (not stripped to '').
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('"')
+    })
+
+    it('Given a two-character pattern \'""\' (empty quoted pattern of length exactly 2), When parsing, Then the quotes are stripped to yield an empty pattern', () => {
+      // Boundary test for `pattern.length >= 2`: at length 2, the
+      // guard fires (>= passes, > fails). This kills the `>` mutation
+      // which would leave the literal `""` as the pattern.
+      const input = '"" merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert — at length exactly 2, quotes are stripped; pattern
+      // becomes the empty string (odd but correct per the spec).
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('')
+    })
+
+    it('Given multiple whitespace separators, When parsing, Then tokenises correctly (no empty attr tokens)', () => {
+      // Arrange — uses tab + double space + triple space. If the
+      // regex mutates to /\s/ (single-char), split produces empty
+      // tokens between consecutive whitespace, which would be parsed
+      // as zero-length attr names.
       const input = '*.xml\t  merge=salesforce-source   text\n'
 
       // Act
@@ -188,6 +295,10 @@ describe('gitAttributesFile.parse', () => {
       if (rule.kind !== 'rule') throw new Error('unreachable')
       expect(rule.attrs.get('merge')).toBe('salesforce-source')
       expect(rule.attrs.get('text')).toBe(true)
+      // Kill /\s+/ → /\s/ mutation: no zero-length attribute names.
+      expect(rule.attrs.has('')).toBe(false)
+      // And the attrs map has exactly what we expect, nothing extra.
+      expect(Array.from(rule.attrs.keys()).sort()).toEqual(['merge', 'text'])
     })
   })
 

--- a/test/unit/utils/gitAttributesFile.test.ts
+++ b/test/unit/utils/gitAttributesFile.test.ts
@@ -1,0 +1,401 @@
+import { EOL } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import {
+  addRule,
+  getMerge,
+  parse,
+  serialise,
+} from '../../../src/utils/gitAttributesFile.js'
+
+describe('gitAttributesFile.parse', () => {
+  describe('empty / absent input', () => {
+    it('Given an empty string, When parsing, Then returns zero lines with os.EOL and a trailing newline', () => {
+      // Arrange
+      const input = ''
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.lines).toEqual([])
+      expect(sut.eol).toBe(EOL)
+      expect(sut.hasTrailingNewline).toBe(true)
+    })
+
+    it('Given a single "\\n" string, When parsing, Then yields one blank line', () => {
+      // Arrange
+      const input = '\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.eol).toBe('\n')
+      expect(sut.lines).toHaveLength(1)
+      expect(sut.lines[0]).toMatchObject({ kind: 'blank' })
+      expect(sut.hasTrailingNewline).toBe(true)
+    })
+  })
+
+  describe('EOL detection', () => {
+    it('Given an LF file, When parsing, Then detects "\\n"', () => {
+      // Arrange
+      const input = '* text=auto\n*.sh text\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.eol).toBe('\n')
+      expect(sut.hasTrailingNewline).toBe(true)
+      expect(sut.lines).toHaveLength(2)
+    })
+
+    it('Given a CRLF file, When parsing, Then detects "\\r\\n"', () => {
+      // Arrange
+      const input = '* text=auto\r\n*.sh text\r\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.eol).toBe('\r\n')
+      expect(sut.hasTrailingNewline).toBe(true)
+    })
+
+    it('Given a mixed-EOL file with CRLF present, When parsing, Then prefers "\\r\\n"', () => {
+      // Arrange — CRLF wins because it's safer to normalise to CRLF on Windows
+      const input = '* text=auto\r\n*.sh text\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.eol).toBe('\r\n')
+    })
+
+    it('Given a file without trailing newline, When parsing, Then hasTrailingNewline is false', () => {
+      // Arrange
+      const input = '* text=auto'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.hasTrailingNewline).toBe(false)
+      expect(sut.lines).toHaveLength(1)
+    })
+  })
+
+  describe('rule parsing', () => {
+    it('Given a bare attribute token, When parsing, Then attrs carries true', () => {
+      // Arrange
+      const input = '*.sh text\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      expect(rule.kind).toBe('rule')
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('*.sh')
+      expect(rule.attrs.get('text')).toBe(true)
+    })
+
+    it('Given a "-attr" token, When parsing, Then attrs carries false', () => {
+      // Arrange
+      const input = '*.bin -text\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.attrs.get('text')).toBe(false)
+    })
+
+    it('Given an "!attr" token after an "attr=value", When parsing, Then the attr is unset in the map', () => {
+      // Arrange — !attr means "unspecified" per git docs; we model that
+      // as a removal from the parsed attrs map so downstream planners
+      // see the same final state git would.
+      const input = '*.xml merge=salesforce-source !merge\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.attrs.has('merge')).toBe(false)
+    })
+
+    it('Given an "attr=value" token, When parsing, Then attrs carries the string value', () => {
+      // Arrange
+      const input = '*.xml merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('*.xml')
+      expect(rule.attrs.get('merge')).toBe('salesforce-source')
+    })
+
+    it('Given a line with multiple attributes, When parsing, Then all are captured', () => {
+      // Arrange
+      const input =
+        '*.profile-meta.xml text=auto eol=lf merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.attrs.get('text')).toBe('auto')
+      expect(rule.attrs.get('eol')).toBe('lf')
+      expect(rule.attrs.get('merge')).toBe('salesforce-source')
+    })
+
+    it('Given a quoted pattern, When parsing, Then strips the surrounding quotes', () => {
+      // Arrange
+      const input = '"*.profile-meta.xml" merge=salesforce-source\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.pattern).toBe('*.profile-meta.xml')
+    })
+
+    it('Given multiple whitespace separators, When parsing, Then tokenises correctly', () => {
+      // Arrange
+      const input = '*.xml\t  merge=salesforce-source   text\n'
+
+      // Act
+      const sut = parse(input)
+      const rule = sut.lines[0]
+
+      // Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(rule.attrs.get('merge')).toBe('salesforce-source')
+      expect(rule.attrs.get('text')).toBe(true)
+    })
+  })
+
+  describe('comment and blank handling', () => {
+    it('Given a comment line, When parsing, Then classifies as comment preserving raw', () => {
+      // Arrange
+      const input = '# a comment\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.lines[0]).toMatchObject({
+        kind: 'comment',
+        raw: '# a comment',
+      })
+    })
+
+    it('Given a blank line, When parsing, Then classifies as blank', () => {
+      // Arrange — three lines, middle one blank
+      const input = '*.xml text\n\n*.sh text\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.lines).toHaveLength(3)
+      expect(sut.lines[1]).toMatchObject({ kind: 'blank' })
+    })
+
+    it('Given a line with only whitespace, When parsing, Then classifies as blank', () => {
+      // Arrange
+      const input = '   \t  \n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.lines[0].kind).toBe('blank')
+    })
+  })
+
+  describe('malformed lines', () => {
+    it('Given a pattern-only line (no attributes), When parsing, Then classifies as malformed and preserves raw', () => {
+      // Arrange
+      const input = '*.xml\n'
+
+      // Act
+      const sut = parse(input)
+
+      // Assert
+      expect(sut.lines[0]).toMatchObject({ kind: 'malformed', raw: '*.xml' })
+    })
+  })
+})
+
+describe('gitAttributesFile.serialise', () => {
+  describe('round-trip invariants (A1-A10)', () => {
+    const fixtures: Array<[label: string, input: string]> = [
+      ['A2 empty with newline', '\n'],
+      ['A3 non-overlapping rules', '* text=auto eol=lf\n*.sh text eol=lf\n'],
+      [
+        'A4 our exact rules',
+        '*.profile-meta.xml merge=salesforce-source\n*.permissionset-meta.xml merge=salesforce-source\n',
+      ],
+      [
+        'A5 our rules + a legacy one',
+        '*.profile-meta.xml merge=salesforce-source\n*.dropped-meta.xml merge=salesforce-source\n',
+      ],
+      [
+        'A6 other driver on our glob',
+        '*.profile-meta.xml merge=some-other-tool\n',
+      ],
+      [
+        'A7 non-merge attrs on our glob',
+        '*.profile-meta.xml text=auto eol=lf\n',
+      ],
+      [
+        'A8 combined line (user attrs + our merge)',
+        '*.profile-meta.xml text=auto merge=salesforce-source\n',
+      ],
+      [
+        'A9 commented out driver',
+        '# *.profile-meta.xml merge=salesforce-source\n',
+      ],
+      ['A10 CRLF', '*.profile-meta.xml merge=salesforce-source\r\n'],
+      ['blank + comments + rules', '# header\n\n*.xml text=auto\n\n# done\n'],
+      ['no trailing newline', '*.xml text=auto'],
+    ]
+
+    it.each(fixtures)('%s round-trips byte-for-byte', (_label, input) => {
+      // Act
+      const parsed = parse(input)
+      const output = serialise(parsed)
+
+      // Assert
+      expect(output).toBe(input)
+    })
+  })
+})
+
+describe('gitAttributesFile.serialise — edge cases', () => {
+  it('Given a parsed empty file, When serialising, Then returns empty string (no EOL)', () => {
+    // Arrange
+    const pf = parse('')
+
+    // Act
+    const out = serialise(pf)
+
+    // Assert
+    expect(out).toBe('')
+  })
+})
+
+describe('gitAttributesFile helpers', () => {
+  describe('getMerge', () => {
+    it('Given a rule line with merge=X, Then returns X', () => {
+      // Arrange
+      const rule = parse('*.xml merge=foo\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(getMerge(rule)).toBe('foo')
+    })
+
+    it('Given a rule line without a merge attribute, Then returns undefined', () => {
+      // Arrange
+      const rule = parse('*.xml text=auto\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(getMerge(rule)).toBeUndefined()
+    })
+
+    it('Given a rule line with merge token (no value), Then returns undefined (bare merge is invalid)', () => {
+      // Arrange
+      const rule = parse('*.xml merge\n').lines[0]
+
+      // Act + Assert
+      if (rule.kind !== 'rule') throw new Error('unreachable')
+      expect(getMerge(rule)).toBeUndefined()
+    })
+  })
+
+  describe('addRule', () => {
+    it('Given a parsed file, When adding a rule, Then the new line is appended and serialisation includes it', () => {
+      // Arrange
+      const pf = parse('* text=auto\n')
+
+      // Act
+      const next = addRule(pf, '*.profile-meta.xml', [
+        ['merge', 'salesforce-source'],
+      ])
+      const out = serialise(next)
+
+      // Assert
+      expect(out).toBe(
+        '* text=auto\n*.profile-meta.xml merge=salesforce-source\n'
+      )
+    })
+
+    it('Given a file without a trailing newline, When adding a rule, Then the result ends with the detected EOL and the new rule on its own line', () => {
+      // Arrange — detected EOL is os.EOL when the file has no newlines
+      const pf = parse('* text=auto')
+
+      // Act
+      const next = addRule(pf, '*.xml', [['merge', 'salesforce-source']])
+      const out = serialise(next)
+
+      // Assert — existing line gets terminated, new line is appended
+      expect(out).toBe(
+        `* text=auto${pf.eol}*.xml merge=salesforce-source${pf.eol}`
+      )
+    })
+
+    it('Given a CRLF file, When adding a rule, Then the new line uses CRLF', () => {
+      // Arrange
+      const pf = parse('* text=auto\r\n')
+
+      // Act
+      const next = addRule(pf, '*.xml', [['merge', 'salesforce-source']])
+      const out = serialise(next)
+
+      // Assert
+      expect(out).toBe('* text=auto\r\n*.xml merge=salesforce-source\r\n')
+    })
+
+    it('Given a bare-true attribute, When adding a rule, Then the rule is written without "=value"', () => {
+      // Arrange
+      const pf = parse('')
+
+      // Act — e.g. pattern carries only the `text` attribute
+      const next = addRule(pf, '*.sh', [['text', true]])
+      const out = serialise(next)
+
+      // Assert
+      expect(out).toContain('*.sh text')
+      expect(out).not.toContain('*.sh text=')
+    })
+
+    it('Given a false attribute, When adding a rule, Then the rule is written with "-attr"', () => {
+      // Arrange
+      const pf = parse('')
+
+      // Act — `-text` marks the glob as binary
+      const next = addRule(pf, '*.bin', [['text', false]])
+      const out = serialise(next)
+
+      // Assert
+      expect(out).toContain('*.bin -text')
+    })
+  })
+})

--- a/test/unit/utils/gitAttributesFile.test.ts
+++ b/test/unit/utils/gitAttributesFile.test.ts
@@ -356,35 +356,32 @@ describe('gitAttributesFile.parse', () => {
 })
 
 describe('gitAttributesFile.serialise', () => {
-  describe('round-trip invariants (A1-A10)', () => {
+  describe('round-trip invariants', () => {
     const fixtures: Array<[label: string, input: string]> = [
-      ['A2 empty with newline', '\n'],
-      ['A3 non-overlapping rules', '* text=auto eol=lf\n*.sh text eol=lf\n'],
+      ['empty with newline', '\n'],
+      ['non-overlapping rules', '* text=auto eol=lf\n*.sh text eol=lf\n'],
       [
-        'A4 our exact rules',
+        'our exact rules',
         '*.profile-meta.xml merge=salesforce-source\n*.permissionset-meta.xml merge=salesforce-source\n',
       ],
       [
-        'A5 our rules + a legacy one',
+        'our rules + a legacy one',
         '*.profile-meta.xml merge=salesforce-source\n*.dropped-meta.xml merge=salesforce-source\n',
       ],
       [
-        'A6 other driver on our glob',
+        'other driver on our glob',
         '*.profile-meta.xml merge=some-other-tool\n',
       ],
+      ['non-merge attrs on our glob', '*.profile-meta.xml text=auto eol=lf\n'],
       [
-        'A7 non-merge attrs on our glob',
-        '*.profile-meta.xml text=auto eol=lf\n',
-      ],
-      [
-        'A8 combined line (user attrs + our merge)',
+        'combined line (user attrs + our merge)',
         '*.profile-meta.xml text=auto merge=salesforce-source\n',
       ],
       [
-        'A9 commented out driver',
+        'commented-out driver',
         '# *.profile-meta.xml merge=salesforce-source\n',
       ],
-      ['A10 CRLF', '*.profile-meta.xml merge=salesforce-source\r\n'],
+      ['CRLF', '*.profile-meta.xml merge=salesforce-source\r\n'],
       ['blank + comments + rules', '# header\n\n*.xml text=auto\n\n# done\n'],
       ['no trailing newline', '*.xml text=auto'],
     ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,12 +5,31 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['**/test/**/*.test.ts'],
-    exclude: ['src', 'e2e', 'node_modules', 'test/utils', 'reports', '.stryker-tmp'],
+    exclude: [
+      'src',
+      'e2e',
+      'node_modules',
+      'test/utils',
+      'reports',
+      '.stryker-tmp',
+    ],
     clearMocks: true,
     coverage: {
       provider: 'v8',
       reportsDirectory: 'reports/coverage',
-      exclude: ['node_modules/', 'test/utils/', 'reports/', 'e2e/'],
+      exclude: [
+        'node_modules/',
+        'test/utils/',
+        'reports/',
+        'e2e/',
+        // oclif command classes have entrypoint side-effects at module
+        // load (readline, Messages.loadMessages, etc.) that aren't
+        // meaningfully unit-coverable without running the command
+        // through oclif itself. They're covered by NUT tests, and any
+        // pure helpers they expose (parsePromptAnswer, etc.) are
+        // exercised by dedicated unit tests.
+        'src/commands/',
+      ],
       reporter: ['lcov'],
       thresholds: {
         branches: 100,


### PR DESCRIPTION
# Explain your changes

---

Rewrites `install`/`uninstall` around a plan-based model so the driver can be installed safely on repos that already have a `.gitattributes` / `.git/info/attributes`:

- **Idempotent install** — re-running install no longer fails; preserves any user attributes already set on our globs and silently dedupes legacy duplicate rules.
- **Conflict detection** — install aborts by default when another merge driver already owns one of our globs, listing every conflict.
- **`--on-conflict=skip|overwrite`** (+ `--force` alias) — choose non-interactively whether to leave conflicting globs to the other driver or take them over. Overwrites are annotated so `uninstall` can restore the original rule.
- **Interactive TTY prompt** — when stdout is a TTY and no `--on-conflict` flag is passed, the user is prompted per-glob.
- **`--dry-run`** on both `install` and `uninstall` — previews the plan (added / skipped / conflicting rules) without touching `.git/config` or `.git/info/attributes`.
- **Uninstall preserves user attributes** — lines like `*.profile-meta.xml text=auto merge=salesforce-source` are rewritten to `*.profile-meta.xml text=auto` instead of being removed.

Also includes a standalone `gitAttributesFile` parser/serialiser + a `GitAttributesPlanner` service so the attribute-file manipulation is unit-testable at 100% mutation.

# Does this close any currently open issues?

---

closes #

- [x] Jest tests added to cover the fix.
- [x] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

New flags on `sf git merge driver install`:
- `--dry-run`
- `--on-conflict=abort|skip|overwrite` (default `abort`)
- `--force` (alias for `--on-conflict=overwrite`)

New flag on `sf git merge driver uninstall`:
- `--dry-run`

# Any other comments

---

## QA recipe (minimal steps, covers every introduced feature)

```bash
# 0. Fresh repo
git init qa-driver && cd qa-driver

# 1. Idempotent install (re-running is a no-op, not an error)
sf git merge driver install
sf git merge driver install
grep 'merge=salesforce-source' .git/info/attributes | head -3

# 2. --dry-run install (prints plan, writes nothing)
sf git merge driver uninstall
sf git merge driver install --dry-run
test ! -f .git/info/attributes && echo "OK: nothing written"

# 3. User attributes are preserved on install AND uninstall
printf '*.profile-meta.xml text=auto\n' > .git/info/attributes
sf git merge driver install
grep '^\*\.profile-meta\.xml' .git/info/attributes   # expect: text=auto merge=salesforce-source
sf git merge driver uninstall
grep '^\*\.profile-meta\.xml' .git/info/attributes   # expect: text=auto (merge= stripped)

# 4. Conflict with another driver → install aborts by default
printf '*.profile-meta.xml merge=other-driver\n' > .git/info/attributes
sf git merge driver install                          # expect: aborts + lists conflicts
grep 'other-driver' .git/info/attributes             # expect: still there, untouched

# 5. --on-conflict=skip leaves the conflicting glob alone, installs the rest
sf git merge driver install --on-conflict=skip
grep 'other-driver' .git/info/attributes             # expect: preserved
grep 'permissionset-meta.xml' .git/info/attributes   # expect: installed
sf git merge driver uninstall

# 6. --force (= --on-conflict=overwrite) takes over, uninstall restores the original
printf '*.profile-meta.xml merge=other-driver\n' > .git/info/attributes
sf git merge driver install --force
grep '^\*\.profile-meta\.xml' .git/info/attributes   # expect: merge=salesforce-source + annotation comment
sf git merge driver uninstall
grep '^\*\.profile-meta\.xml' .git/info/attributes   # expect: merge=other-driver restored

# 7. Interactive TTY prompt (run from a real terminal, no flag)
printf '*.profile-meta.xml merge=other-driver\n' > .git/info/attributes
sf git merge driver install                          # expect: prompt per conflict

# 8. --dry-run uninstall
sf git merge driver install
sf git merge driver uninstall --dry-run
grep 'merge=salesforce-source' .git/info/attributes >/dev/null && echo "OK: still installed"
```