### PR TITLE
fix(release): anchor release-please to existing v-prefixed tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
# Explain your changes

---

Release-please's manifest mode defaults `include-component-in-tag` to `true` when a package has a name. The component is derived from `package.json` → `sf-git-merge-driver`, so release-please started looking for previous releases tagged `sf-git-merge-driver-vX.Y.Z`.

Existing release tags are plain `vX.Y.Z` (e.g. `v1.6.1`), so release-please can't find its anchor and walks history from the very first commit. The result is the runaway changelog seen in #185, which lists every `feat`/`fix` since #3.

Setting `"include-component-in-tag": false` keeps the tag format as `vX.Y.Z`, matching the existing `v1.6.1` tag, so release-please correctly scopes the next changelog to commits since `v1.6.1`.