### PR TITLE
feat: add tabSettings and servicePresenceStatusAccesses key extractors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
-        "@commitlint/config-conventional": "^21.0.0",
+        "@commitlint/config-conventional": "^21.0.1",
         "@oclif/plugin-help": "^6.2.48",
         "@salesforce/cli-plugins-testkit": "^5.3.57",
         "@salesforce/dev-config": "^4.3.3",
@@ -33,7 +33,7 @@
         "chai": "^6.2.2",
         "esbuild": "^0.28.0",
         "husky": "^9.1.7",
-        "knip": "^6.12.2",
+        "knip": "^6.13.1",
         "mocha": "^11.7.5",
         "nyc": "^18.0.0",
         "oclif": "^4.23.0",
@@ -1653,13 +1653,13 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.0.tgz",
-      "integrity": "sha512-QJX/rPK4Yu3f5J4OCIBy5aXq2e0EEdwSDFZ3NQvFAXTm3gs12ipyZ+yjhZxm3hHn6DB8wuv3zhFTL1I2tYzUBA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.1.tgz",
+      "integrity": "sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.0.0",
+        "@commitlint/types": "^21.0.1",
         "conventional-changelog-conventionalcommits": "^9.2.0"
       },
       "engines": {
@@ -1667,9 +1667,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-      "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3557,9 +3557,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
-      "integrity": "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
+      "integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
       "cpu": [
         "arm"
       ],
@@ -3574,9 +3574,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
-      "integrity": "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
+      "integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
       "cpu": [
         "arm64"
       ],
@@ -3591,9 +3591,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
-      "integrity": "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
+      "integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
       "cpu": [
         "arm64"
       ],
@@ -3608,9 +3608,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
-      "integrity": "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
+      "integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
       "cpu": [
         "x64"
       ],
@@ -3625,9 +3625,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
-      "integrity": "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
+      "integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
       "cpu": [
         "x64"
       ],
@@ -3642,9 +3642,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
-      "integrity": "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
+      "integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
       "cpu": [
         "arm"
       ],
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
-      "integrity": "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
+      "integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
       "cpu": [
         "arm"
       ],
@@ -3676,9 +3676,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
-      "integrity": "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
+      "integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
       "cpu": [
         "arm64"
       ],
@@ -3696,9 +3696,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
-      "integrity": "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
+      "integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
       "cpu": [
         "arm64"
       ],
@@ -3716,9 +3716,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
-      "integrity": "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
+      "integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
       "cpu": [
         "ppc64"
       ],
@@ -3736,9 +3736,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
-      "integrity": "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
+      "integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
       "cpu": [
         "riscv64"
       ],
@@ -3756,9 +3756,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
-      "integrity": "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
+      "integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
       "cpu": [
         "riscv64"
       ],
@@ -3776,9 +3776,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
-      "integrity": "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
+      "integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
       "cpu": [
         "s390x"
       ],
@@ -3796,9 +3796,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
-      "integrity": "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
+      "integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
       "cpu": [
         "x64"
       ],
@@ -3816,9 +3816,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
-      "integrity": "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
+      "integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
       "cpu": [
         "x64"
       ],
@@ -3836,9 +3836,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
-      "integrity": "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
+      "integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
       "cpu": [
         "arm64"
       ],
@@ -3853,9 +3853,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
-      "integrity": "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
+      "integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
       "cpu": [
         "wasm32"
       ],
@@ -3872,9 +3872,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
-      "integrity": "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
+      "integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
       "cpu": [
         "arm64"
       ],
@@ -3889,9 +3889,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
-      "integrity": "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
+      "integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
       "cpu": [
         "ia32"
       ],
@@ -3906,9 +3906,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
-      "integrity": "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
+      "integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
       "cpu": [
         "x64"
       ],
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9227,9 +9227,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.12.2.tgz",
-      "integrity": "sha512-RcZpT1sVziKZgDk1F0hAcp+bq71VJAF8vg1Y9ZLXc1+UXQaMm1rjiUqpJQTIj+lqwmiBQT19/u7ikgazs23cvA==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.13.1.tgz",
+      "integrity": "sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==",
       "dev": true,
       "funding": [
         {
@@ -9248,14 +9248,14 @@
         "get-tsconfig": "4.14.0",
         "jiti": "^2.7.0",
         "minimist": "^1.2.8",
-        "oxc-parser": "^0.128.0",
+        "oxc-parser": "^0.130.0",
         "oxc-resolver": "^11.19.1",
         "picomatch": "^4.0.4",
         "smol-toml": "^1.6.1",
         "strip-json-comments": "5.0.3",
         "tinyglobby": "^0.2.16",
         "unbash": "^3.0.0",
-        "yaml": "^2.8.2",
+        "yaml": "^2.9.0",
         "zod": "^4.1.11"
       },
       "bin": {
@@ -10869,13 +10869,13 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.128.0.tgz",
-      "integrity": "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
+      "integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.128.0"
+        "@oxc-project/types": "^0.130.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -10884,26 +10884,26 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.128.0",
-        "@oxc-parser/binding-android-arm64": "0.128.0",
-        "@oxc-parser/binding-darwin-arm64": "0.128.0",
-        "@oxc-parser/binding-darwin-x64": "0.128.0",
-        "@oxc-parser/binding-freebsd-x64": "0.128.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.128.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.128.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.128.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.128.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.128.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.128.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.128.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.128.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.130.0",
+        "@oxc-parser/binding-android-arm64": "0.130.0",
+        "@oxc-parser/binding-darwin-arm64": "0.130.0",
+        "@oxc-parser/binding-darwin-x64": "0.130.0",
+        "@oxc-parser/binding-freebsd-x64": "0.130.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.130.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.130.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.130.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.130.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.130.0"
       }
     },
     "node_modules/oxc-resolver": {
@@ -14083,9 +14083,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
-    "@commitlint/config-conventional": "^21.0.0",
+    "@commitlint/config-conventional": "^21.0.1",
     "@oclif/plugin-help": "^6.2.48",
     "@salesforce/cli-plugins-testkit": "^5.3.57",
     "@salesforce/dev-config": "^4.3.3",
@@ -34,7 +34,7 @@
     "chai": "^6.2.2",
     "esbuild": "^0.28.0",
     "husky": "^9.1.7",
-    "knip": "^6.12.2",
+    "knip": "^6.13.1",
     "mocha": "^11.7.5",
     "nyc": "^18.0.0",
     "oclif": "^4.23.0",

--- a/src/service/MetadataService.ts
+++ b/src/service/MetadataService.ts
@@ -85,7 +85,8 @@ const METADATA_KEY_EXTRACTORS = {
   profileActionOverrides: (el: JsonValue) => getPropertyValue(el, 'actionName'), // Profile
   recordTypeVisibilities: (el: JsonValue) => getPropertyValue(el, 'recordType'), // Profile // PermissionSet
   servicePresenceStatusAccesses: (el: JsonValue) =>
-    getPropertyValue(el, 'servicePresenceStatus'), // Profile
+    getPropertyValue(el, 'servicePresenceStatus'), // Profile // PermissionSet
+  tabSettings: (el: JsonValue) => getPropertyValue(el, 'tab'), // PermissionSet
   tabVisibilities: (el: JsonValue) => getPropertyValue(el, 'tab'), // Profile // PermissionSet
   userPermissions: (el: JsonValue) => getPropertyValue(el, 'name'), // Profile // PermissionSet
   dataspaceScopes: (el: JsonValue) => getPropertyValue(el, 'dataspaceScope'), // PermissionSet

--- a/src/service/MetadataService.ts
+++ b/src/service/MetadataService.ts
@@ -86,13 +86,13 @@ const METADATA_KEY_EXTRACTORS = {
   recordTypeVisibilities: (el: JsonValue) => getPropertyValue(el, 'recordType'), // Profile // PermissionSet
   servicePresenceStatusAccesses: (el: JsonValue) =>
     getPropertyValue(el, 'servicePresenceStatus'), // Profile // PermissionSet
-  tabSettings: (el: JsonValue) => getPropertyValue(el, 'tab'), // PermissionSet
   tabVisibilities: (el: JsonValue) => getPropertyValue(el, 'tab'), // Profile // PermissionSet
   userPermissions: (el: JsonValue) => getPropertyValue(el, 'name'), // Profile // PermissionSet
   dataspaceScopes: (el: JsonValue) => getPropertyValue(el, 'dataspaceScope'), // PermissionSet
   emailRoutingAddressAccesses: (el: JsonValue) => getPropertyValue(el, 'name'), // PermissionSet
   externalCredentialPrincipalAccesses: (el: JsonValue) =>
     getPropertyValue(el, 'externalCredentialPrincipal'), // PermissionSet
+  tabSettings: (el: JsonValue) => getPropertyValue(el, 'tab'), // PermissionSet
   sharingCriteriaRules: (el: JsonValue) => getPropertyValue(el, 'fullName'), // SharingRules
   sharingGuestRules: (el: JsonValue) => getPropertyValue(el, 'fullName'), // SharingRules
   sharingOwnerRules: (el: JsonValue) => getPropertyValue(el, 'fullName'), // SharingRules

--- a/src/service/MetadataService.ts
+++ b/src/service/MetadataService.ts
@@ -84,6 +84,8 @@ const METADATA_KEY_EXTRACTORS = {
   pageAccesses: (el: JsonValue) => getPropertyValue(el, 'apexPage'), // Profile // PermissionSet
   profileActionOverrides: (el: JsonValue) => getPropertyValue(el, 'actionName'), // Profile
   recordTypeVisibilities: (el: JsonValue) => getPropertyValue(el, 'recordType'), // Profile // PermissionSet
+  servicePresenceStatusAccesses: (el: JsonValue) =>
+    getPropertyValue(el, 'servicePresenceStatus'), // Profile
   tabVisibilities: (el: JsonValue) => getPropertyValue(el, 'tab'), // Profile // PermissionSet
   userPermissions: (el: JsonValue) => getPropertyValue(el, 'name'), // Profile // PermissionSet
   dataspaceScopes: (el: JsonValue) => getPropertyValue(el, 'dataspaceScope'), // PermissionSet

--- a/test/unit/merger/nodes/KeyedArrayMergeNode.test.ts
+++ b/test/unit/merger/nodes/KeyedArrayMergeNode.test.ts
@@ -7,9 +7,6 @@ import { defaultConfig } from '../../../utils/testConfig.js'
 const fieldPermissionsKey =
   MetadataService.getKeyFieldExtractor('fieldPermissions')
 const picklistValueKey = MetadataService.getKeyFieldExtractor('value')
-const servicePresenceStatusAccessesKey = MetadataService.getKeyFieldExtractor(
-  'servicePresenceStatusAccesses'
-)
 
 describe('KeyedArrayMergeNode', () => {
   describe('merge with key field (fieldPermissions)', () => {
@@ -564,86 +561,6 @@ describe('KeyedArrayMergeNode', () => {
 
       // Assert
       expect(result.hasConflict).toBe(true)
-    })
-  })
-
-  describe('merge with key field (servicePresenceStatusAccesses)', () => {
-    it('should merge identical arrays without conflict', () => {
-      // Arrange
-      const entries = [
-        { enabled: 'false', servicePresenceStatus: 'Available' },
-        { enabled: 'false', servicePresenceStatus: 'Busy' },
-        { enabled: 'false', servicePresenceStatus: 'On_Break' },
-        { enabled: 'false', servicePresenceStatus: 'Vacation' },
-      ]
-      const ancestor = [...entries]
-      const local = [...entries]
-      const other = [...entries]
-      const node = new KeyedArrayMergeNode(
-        ancestor,
-        local,
-        other,
-        'servicePresenceStatusAccesses',
-        servicePresenceStatusAccessesKey,
-        false
-      )
-
-      // Act
-      const result = node.merge(defaultConfig)
-
-      // Assert
-      expect(result.hasConflict).toBe(false)
-      expect(result.output.length).toBe(4)
-    })
-
-    it('should add new status from other without conflict', () => {
-      // Arrange
-      const ancestor = [
-        { enabled: 'false', servicePresenceStatus: 'Available' },
-      ]
-      const local = [{ enabled: 'false', servicePresenceStatus: 'Available' }]
-      const other = [
-        { enabled: 'false', servicePresenceStatus: 'Available' },
-        { enabled: 'false', servicePresenceStatus: 'Busy' },
-      ]
-      const node = new KeyedArrayMergeNode(
-        ancestor,
-        local,
-        other,
-        'servicePresenceStatusAccesses',
-        servicePresenceStatusAccessesKey,
-        false
-      )
-
-      // Act
-      const result = node.merge(defaultConfig)
-
-      // Assert
-      expect(result.hasConflict).toBe(false)
-      expect(result.output.length).toBe(2)
-    })
-
-    it('should handle modification in one side without conflict', () => {
-      // Arrange
-      const ancestor = [
-        { enabled: 'false', servicePresenceStatus: 'Available' },
-      ]
-      const local = [{ enabled: 'false', servicePresenceStatus: 'Available' }]
-      const other = [{ enabled: 'true', servicePresenceStatus: 'Available' }]
-      const node = new KeyedArrayMergeNode(
-        ancestor,
-        local,
-        other,
-        'servicePresenceStatusAccesses',
-        servicePresenceStatusAccessesKey,
-        false
-      )
-
-      // Act
-      const result = node.merge(defaultConfig)
-
-      // Assert
-      expect(result.hasConflict).toBe(false)
     })
   })
 

--- a/test/unit/merger/nodes/KeyedArrayMergeNode.test.ts
+++ b/test/unit/merger/nodes/KeyedArrayMergeNode.test.ts
@@ -7,6 +7,9 @@ import { defaultConfig } from '../../../utils/testConfig.js'
 const fieldPermissionsKey =
   MetadataService.getKeyFieldExtractor('fieldPermissions')
 const picklistValueKey = MetadataService.getKeyFieldExtractor('value')
+const servicePresenceStatusAccessesKey = MetadataService.getKeyFieldExtractor(
+  'servicePresenceStatusAccesses'
+)
 
 describe('KeyedArrayMergeNode', () => {
   describe('merge with key field (fieldPermissions)', () => {
@@ -580,7 +583,9 @@ describe('KeyedArrayMergeNode', () => {
         ancestor,
         local,
         other,
-        'servicePresenceStatusAccesses'
+        'servicePresenceStatusAccesses',
+        servicePresenceStatusAccessesKey,
+        false
       )
 
       // Act
@@ -605,7 +610,9 @@ describe('KeyedArrayMergeNode', () => {
         ancestor,
         local,
         other,
-        'servicePresenceStatusAccesses'
+        'servicePresenceStatusAccesses',
+        servicePresenceStatusAccessesKey,
+        false
       )
 
       // Act
@@ -627,7 +634,9 @@ describe('KeyedArrayMergeNode', () => {
         ancestor,
         local,
         other,
-        'servicePresenceStatusAccesses'
+        'servicePresenceStatusAccesses',
+        servicePresenceStatusAccessesKey,
+        false
       )
 
       // Act

--- a/test/unit/merger/nodes/KeyedArrayMergeNode.test.ts
+++ b/test/unit/merger/nodes/KeyedArrayMergeNode.test.ts
@@ -564,6 +564,80 @@ describe('KeyedArrayMergeNode', () => {
     })
   })
 
+  describe('merge with key field (servicePresenceStatusAccesses)', () => {
+    it('should merge identical arrays without conflict', () => {
+      // Arrange
+      const entries = [
+        { enabled: 'false', servicePresenceStatus: 'Available' },
+        { enabled: 'false', servicePresenceStatus: 'Busy' },
+        { enabled: 'false', servicePresenceStatus: 'On_Break' },
+        { enabled: 'false', servicePresenceStatus: 'Vacation' },
+      ]
+      const ancestor = [...entries]
+      const local = [...entries]
+      const other = [...entries]
+      const node = new KeyedArrayMergeNode(
+        ancestor,
+        local,
+        other,
+        'servicePresenceStatusAccesses'
+      )
+
+      // Act
+      const result = node.merge(defaultConfig)
+
+      // Assert
+      expect(result.hasConflict).toBe(false)
+      expect(result.output.length).toBe(4)
+    })
+
+    it('should add new status from other without conflict', () => {
+      // Arrange
+      const ancestor = [
+        { enabled: 'false', servicePresenceStatus: 'Available' },
+      ]
+      const local = [{ enabled: 'false', servicePresenceStatus: 'Available' }]
+      const other = [
+        { enabled: 'false', servicePresenceStatus: 'Available' },
+        { enabled: 'false', servicePresenceStatus: 'Busy' },
+      ]
+      const node = new KeyedArrayMergeNode(
+        ancestor,
+        local,
+        other,
+        'servicePresenceStatusAccesses'
+      )
+
+      // Act
+      const result = node.merge(defaultConfig)
+
+      // Assert
+      expect(result.hasConflict).toBe(false)
+      expect(result.output.length).toBe(2)
+    })
+
+    it('should handle modification in one side without conflict', () => {
+      // Arrange
+      const ancestor = [
+        { enabled: 'false', servicePresenceStatus: 'Available' },
+      ]
+      const local = [{ enabled: 'false', servicePresenceStatus: 'Available' }]
+      const other = [{ enabled: 'true', servicePresenceStatus: 'Available' }]
+      const node = new KeyedArrayMergeNode(
+        ancestor,
+        local,
+        other,
+        'servicePresenceStatusAccesses'
+      )
+
+      // Act
+      const result = node.merge(defaultConfig)
+
+      // Assert
+      expect(result.hasConflict).toBe(false)
+    })
+  })
+
   describe('merge without key field (unknown attribute)', () => {
     it('should create conflict for arrays without key extractor', () => {
       // Arrange

--- a/test/unit/service/MetadataService.test.ts
+++ b/test/unit/service/MetadataService.test.ts
@@ -238,6 +238,12 @@ describe('MetadataService', () => {
           expected: 'Available',
         },
         {
+          name: 'handles tabSettings with tab',
+          metadataType: 'tabSettings',
+          testObject: { tab: 'TestTab' },
+          expected: 'TestTab',
+        },
+        {
           name: 'handles tabVisibilities with tab',
           metadataType: 'tabVisibilities',
           testObject: { tab: 'TestTab' },

--- a/test/unit/service/MetadataService.test.ts
+++ b/test/unit/service/MetadataService.test.ts
@@ -232,6 +232,12 @@ describe('MetadataService', () => {
           expected: 'TestRecordType',
         },
         {
+          name: 'handles servicePresenceStatusAccesses with servicePresenceStatus',
+          metadataType: 'servicePresenceStatusAccesses',
+          testObject: { servicePresenceStatus: 'Available' },
+          expected: 'Available',
+        },
+        {
           name: 'handles tabVisibilities with tab',
           metadataType: 'tabVisibilities',
           testObject: { tab: 'TestTab' },


### PR DESCRIPTION
## Summary
This PR adds key extractors for:
* `tabSettings` (PermissionSet)
* `servicePresenceStatusAccesses` (Profile / PermissionSet)

This allows the merge driver to correctly align and resolve 3-way merges for these array elements based on their unique keys (`tab` and `servicePresenceStatus` respectively), rather than relying on index-based merging. Unit tests have been included to verify the new extractors and merge behavior.